### PR TITLE
Slice 930: blog/changelog templates + static regen gates

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "test:e2e": "node scripts/test-e2e-home-leaderboard.mjs",
     "test:smoke": "node scripts/test-smoke-routes.mjs",
     "test:a11y": "node scripts/test-a11y.mjs",
-    "test:visual": "node scripts/test-visual.mjs"
+    "test:visual": "node scripts/test-visual.mjs",
+    "test:e2e:blog-changelog": "node scripts/test-e2e-blog-changelog.mjs",
+    "content:trigger:simulate": "node scripts/content-trigger-simulate.mjs",
+    "sitemap:generate": "node scripts/sitemap-generate.mjs",
+    "feeds:generate": "node scripts/feeds-generate.mjs"
   },
   "devDependencies": {
     "c8": "^10.1.3"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { getContentRoot, loadCollection } from "../src/content-utils.mjs";
-import { renderHomePage, renderLeaderboardPage, renderSimplePage } from "../src/pages.mjs";
+import { renderHomePage, renderLeaderboardPage, renderSimplePage, renderBlogIndex, renderBlogDetail, renderBlogArchive, renderChangelogIndex, renderChangelogDetail } from "../src/pages.mjs";
 
 const dist = path.resolve(process.cwd(), "dist");
 const contentRoot = getContentRoot();
-
 const blogEntries = loadCollection(contentRoot, "blog");
 const changelogEntries = loadCollection(contentRoot, "changelog");
 const rulesEntries = loadCollection(contentRoot, "rules");
@@ -21,21 +21,23 @@ fs.mkdirSync(dist, { recursive: true });
 
 writePage(path.join(dist, "index.html"), renderHomePage({ rulesCount: rulesEntries.length, blogCount: blogEntries.length }));
 writePage(path.join(dist, "leaderboard/index.html"), renderLeaderboardPage(seedLeaderboard));
-writePage(path.join(dist, "blog/index.html"), renderSimplePage("Blog"));
-writePage(path.join(dist, "changelog/index.html"), renderSimplePage("Changelog"));
+writePage(path.join(dist, "blog/index.html"), renderBlogIndex(blogEntries));
+writePage(path.join(dist, "blog/archive/index.html"), renderBlogArchive(blogEntries));
+writePage(path.join(dist, "changelog/index.html"), renderChangelogIndex(changelogEntries));
 writePage(path.join(dist, "rules/index.html"), renderSimplePage("Rules"));
 writePage(path.join(dist, "404.html"), renderSimplePage("Not Found"));
 
-for (const entry of blogEntries) {
-  writePage(path.join(dist, "blog", entry.metadata.slug, "index.html"), renderSimplePage(entry.metadata.title));
-}
-for (const entry of changelogEntries) {
-  writePage(path.join(dist, "changelog", entry.metadata.slug, "index.html"), renderSimplePage(entry.metadata.title));
-}
+for (const entry of blogEntries) writePage(path.join(dist, "blog", entry.metadata.slug, "index.html"), renderBlogDetail(entry));
+for (const entry of changelogEntries) writePage(path.join(dist, "changelog", entry.metadata.slug, "index.html"), renderChangelogDetail(entry));
 
-function writePage(filePath, html) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, html, "utf8");
-}
+writeJson(path.join(dist, ".regen-manifest.json"), {
+  generatedAt: new Date().toISOString(),
+  sourceHash: createHash("sha256").update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]) })).digest("hex"),
+  blogRoutes: blogEntries.map((entry) => `/blog/${entry.metadata.slug}`),
+  changelogRoutes: changelogEntries.map((entry) => `/changelog/${entry.metadata.slug}`)
+});
 
-console.log("build complete: marketing + leaderboard routes generated");
+console.log("build complete: blog + changelog + marketing routes generated");
+
+function writePage(filePath, html) { fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, html, "utf8"); }
+function writeJson(filePath, value) { fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8"); }

--- a/scripts/content-trigger-simulate.mjs
+++ b/scripts/content-trigger-simulate.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+const fromArg = process.argv.find((arg) => arg.startsWith("--from="));
+const verify = process.argv.includes("--verify-static-regen");
+const fromPath = fromArg ? fromArg.split("=")[1] : "../content";
+assert.ok(fs.existsSync(path.resolve(process.cwd(), fromPath)), `missing content path ${fromPath}`);
+execSync("node scripts/build.mjs", { stdio: "pipe" });
+const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), "dist/.regen-manifest.json"), "utf8"));
+assert.ok(Array.isArray(manifest.blogRoutes));
+assert.ok(Array.isArray(manifest.changelogRoutes));
+if (verify) {
+  assert.ok(manifest.blogRoutes.length > 0, "expected updated blog artifacts");
+  assert.ok(manifest.changelogRoutes.length > 0, "expected updated changelog artifacts");
+}
+console.log(`content trigger simulation ok from=${fromPath} verify=${verify}`);

--- a/scripts/feeds-generate.mjs
+++ b/scripts/feeds-generate.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { getContentRoot, loadCollection } from "../src/content-utils.mjs";
+
+execSync("node scripts/build.mjs", { stdio: "pipe" });
+const blog = loadCollection(getContentRoot(), "blog");
+const changelog = loadCollection(getContentRoot(), "changelog");
+const all = [...blog, ...changelog].sort((a, b) => String(b.metadata.publishedAt).localeCompare(String(a.metadata.publishedAt)));
+const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"><channel><title>Kriegspiel Updates</title><link>https://kriegspiel.org</link>${all.map((entry) => `<item><title>${entry.metadata.title}</title><link>https://kriegspiel.org/${entry.collection}/${entry.metadata.slug}</link><pubDate>${new Date(entry.metadata.publishedAt).toUTCString()}</pubDate><description>${entry.metadata.summary}</description></item>`).join("")}</channel></rss>\n`;
+const atom = `<?xml version="1.0" encoding="UTF-8"?>\n<feed xmlns="http://www.w3.org/2005/Atom"><title>Kriegspiel Updates</title><id>https://kriegspiel.org</id>${all.map((entry) => `<entry><title>${entry.metadata.title}</title><id>https://kriegspiel.org/${entry.collection}/${entry.metadata.slug}</id><updated>${new Date(entry.metadata.updatedAt).toISOString()}</updated><summary>${entry.metadata.summary}</summary></entry>`).join("")}</feed>\n`;
+fs.writeFileSync(path.join(process.cwd(), "dist/feed.xml"), rss, "utf8");
+fs.writeFileSync(path.join(process.cwd(), "dist/atom.xml"), atom, "utf8");
+if (process.argv.includes("--check")) { assert.ok(rss.includes("<item>")); assert.ok(atom.includes("<entry>")); }
+console.log("feeds generated: rss + atom");

--- a/scripts/sitemap-generate.mjs
+++ b/scripts/sitemap-generate.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+execSync("node scripts/build.mjs", { stdio: "pipe" });
+const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), "dist/.regen-manifest.json"), "utf8"));
+const urls = ["/", "/leaderboard", "/blog", "/blog/archive", "/changelog", "/rules", ...manifest.blogRoutes, ...manifest.changelogRoutes];
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map((u) => `  <url><loc>https://kriegspiel.org${u}</loc></url>`).join("\n")}\n</urlset>\n`;
+fs.writeFileSync(path.join(process.cwd(), "dist/sitemap.xml"), xml, "utf8");
+if (process.argv.includes("--check")) {
+  assert.ok(xml.includes("https://kriegspiel.org/blog"));
+  assert.ok(xml.includes("https://kriegspiel.org/changelog"));
+}
+console.log("sitemap generated");

--- a/scripts/test-e2e-blog-changelog.mjs
+++ b/scripts/test-e2e-blog-changelog.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+execSync("node scripts/build.mjs", { stdio: "pipe" });
+const blog = fs.readFileSync(path.join(process.cwd(), "dist/blog/index.html"), "utf8");
+const changelog = fs.readFileSync(path.join(process.cwd(), "dist/changelog/index.html"), "utf8");
+assert.ok(blog.includes("/blog/archive"));
+assert.ok(blog.includes("min read"));
+assert.ok(changelog.includes("Versioned release history"));
+for (const route of ["dist/blog/welcome/index.html", "dist/changelog/2026-03-27-slice-910/index.html"]) {
+  assert.ok(fs.existsSync(path.join(process.cwd(), route)), `missing detail route ${route}`);
+}
+console.log("e2e ok: blog + changelog routes and linking");

--- a/scripts/test-e2e-home-leaderboard.mjs
+++ b/scripts/test-e2e-home-leaderboard.mjs
@@ -4,12 +4,26 @@ import path from "node:path";
 import { execSync } from "node:child_process";
 
 execSync("node scripts/build.mjs", { stdio: "pipe" });
-const home = fs.readFileSync(path.join(process.cwd(), "dist", "index.html"), "utf8");
-const leaderboard = fs.readFileSync(path.join(process.cwd(), "dist", "leaderboard", "index.html"), "utf8");
+const idx = process.argv.indexOf("--grep");
+const grepEq = process.argv.find((arg) => arg.startsWith("--grep="));
+const grep = idx >= 0 ? process.argv[idx + 1] : (grepEq ? grepEq.split("=")[1] : "home|leaderboard");
 
-assert.ok(home.includes('href="/leaderboard"'));
-assert.ok(leaderboard.includes('id="leaderboard-table"'));
-assert.ok(leaderboard.includes("fetch('/api/leaderboard'"));
-assert.ok(leaderboard.includes('href="/rules"'));
+if (/home|leaderboard/.test(grep)) {
+  const home = fs.readFileSync(path.join(process.cwd(), "dist", "index.html"), "utf8");
+  const leaderboard = fs.readFileSync(path.join(process.cwd(), "dist", "leaderboard", "index.html"), "utf8");
+  assert.ok(home.includes(href="/leaderboard"));
+  assert.ok(leaderboard.includes(id="leaderboard-table"));
+  assert.ok(leaderboard.includes("fetch(/api/leaderboard"));
+  assert.ok(leaderboard.includes(href="/rules"));
+}
 
-console.log("e2e ok: home -> leaderboard -> rules journey present");
+if (/blog|changelog/.test(grep)) {
+  const blog = fs.readFileSync(path.join(process.cwd(), "dist", "blog", "index.html"), "utf8");
+  const changelog = fs.readFileSync(path.join(process.cwd(), "dist", "changelog", "index.html"), "utf8");
+  assert.ok(blog.includes("/blog/archive"));
+  assert.ok(changelog.includes("Versioned release history"));
+  assert.ok(fs.existsSync(path.join(process.cwd(), "dist", "blog", "welcome", "index.html")));
+  assert.ok(fs.existsSync(path.join(process.cwd(), "dist", "changelog", "2026-03-27-slice-910", "index.html")));
+}
+
+console.log(`e2e ok: ${grep}`);

--- a/src/content-utils.mjs
+++ b/src/content-utils.mjs
@@ -1,36 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 
-export const REQUIRED_FIELDS = [
-  "title",
-  "slug",
-  "summary",
-  "publishedAt",
-  "updatedAt",
-  "author",
-  "tags",
-  "draft"
-];
+export const REQUIRED_FIELDS = ["title", "slug", "summary", "publishedAt", "updatedAt", "author", "tags", "draft"];
 
 export function parseFrontmatter(raw) {
   const lines = raw.split(/\r?\n/);
   if (lines[0] !== "---") return { metadata: {}, body: raw };
-
   let idx = 1;
   const metadata = {};
   for (; idx < lines.length; idx += 1) {
     const line = lines[idx];
-    if (line === "---") {
-      idx += 1;
-      break;
-    }
+    if (line === "---") { idx += 1; break; }
     const separator = line.indexOf(":");
     if (separator < 1) continue;
     const key = line.slice(0, separator).trim();
     const value = line.slice(separator + 1).trim();
     metadata[key] = parseValue(value);
   }
-
   return { metadata, body: lines.slice(idx).join("\n") };
 }
 
@@ -40,54 +27,61 @@ function parseValue(value) {
   if (value.startsWith("[") && value.endsWith("]")) {
     const inner = value.slice(1, -1).trim();
     if (!inner) return [];
-    return inner.split(",").map((part) => {
-      const trimmed = part.trim();
-      return trimmed.replace(/^"|"$/g, "");
-    });
+    return inner.split(",").map((part) => part.trim().replace(/^"|"$/g, ""));
   }
   return value.replace(/^"|"$/g, "");
+}
+
+export function markdownToHtml(markdown) {
+  return markdown.split(/\r?\n\r?\n/).map((block) => {
+    const trimmed = block.trim();
+    if (!trimmed) return "";
+    if (/^##\s+/.test(trimmed)) return `<h2>${escapeHtml(trimmed.replace(/^##\s+/, ""))}</h2>`;
+    if (/^#\s+/.test(trimmed)) return `<h1>${escapeHtml(trimmed.replace(/^#\s+/, ""))}</h1>`;
+    if (/^-\s+/m.test(trimmed)) {
+      const items = trimmed.split(/\r?\n/).filter((line) => line.startsWith("- ")).map((line) => `<li>${inlineMarkdown(line.slice(2))}</li>`).join("");
+      return `<ul>${items}</ul>`;
+    }
+    return `<p>${inlineMarkdown(trimmed)}</p>`;
+  }).join("\n");
+}
+
+function inlineMarkdown(text) {
+  return escapeHtml(text)
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/`(.+?)`/g, "<code>$1</code>")
+    .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>');
+}
+
+function escapeHtml(value) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
 }
 
 export function loadCollection(contentRoot, collection) {
   const dir = path.join(contentRoot, collection);
   if (!fs.existsSync(dir)) return [];
-  return fs
-    .readdirSync(dir)
+  const includeDrafts = ["1", "true"].includes(String(process.env.KS_PREVIEW_DRAFTS).toLowerCase());
+  return fs.readdirSync(dir)
     .filter((file) => file.endsWith(".md") && file.toLowerCase() !== "readme.md")
     .map((file) => {
       const fullPath = path.join(dir, file);
       const raw = fs.readFileSync(fullPath, "utf8");
       const { metadata, body } = parseFrontmatter(raw);
-      return { collection, file, fullPath, metadata, body };
-    });
+      return { collection, file, fullPath, metadata, body, bodyHtml: markdownToHtml(body.trim()) };
+    })
+    .filter((entry) => includeDrafts || entry.metadata.draft !== true)
+    .sort((a, b) => String(b.metadata.publishedAt).localeCompare(String(a.metadata.publishedAt)));
 }
 
 export function validateEntry(entry) {
   const issues = [];
-
-  for (const field of REQUIRED_FIELDS) {
-    if (!(field in entry.metadata)) {
-      issues.push(`${entry.collection}/${entry.file}: missing required field ${field}`);
-    }
-  }
-
-  if (entry.collection !== "blog" && !("version" in entry.metadata)) {
-    issues.push(`${entry.collection}/${entry.file}: missing required field version for ${entry.collection}`);
-  }
-
-  if (entry.metadata.tags && !Array.isArray(entry.metadata.tags)) {
-    issues.push(`${entry.collection}/${entry.file}: tags must be an array`);
-  }
-
-  for (const dateField of ["publishedAt", "updatedAt"]) {
-    if (entry.metadata[dateField] && Number.isNaN(Date.parse(entry.metadata[dateField]))) {
-      issues.push(`${entry.collection}/${entry.file}: ${dateField} must be a valid date`);
-    }
-  }
-
+  for (const field of REQUIRED_FIELDS) if (!(field in entry.metadata)) issues.push(`${entry.collection}/${entry.file}: missing required field ${field}`);
+  if (entry.collection !== "blog" && !("version" in entry.metadata)) issues.push(`${entry.collection}/${entry.file}: missing required field version for ${entry.collection}`);
+  if (entry.metadata.tags && !Array.isArray(entry.metadata.tags)) issues.push(`${entry.collection}/${entry.file}: tags must be an array`);
+  for (const dateField of ["publishedAt", "updatedAt"]) if (entry.metadata[dateField] && Number.isNaN(Date.parse(entry.metadata[dateField]))) issues.push(`${entry.collection}/${entry.file}: ${dateField} must be a valid date`);
   return issues;
 }
 
-export function getContentRoot() {
-  return path.resolve(process.cwd(), process.env.KS_CONTENT_PATH || "../content");
-}
+export function getContentRoot() { return path.resolve(process.cwd(), process.env.KS_CONTENT_PATH || "../content"); }
+export function readingTimeMinutes(text) { const words = text.trim().split(/\s+/).filter(Boolean).length; return Math.max(1, Math.ceil(words / 220)); }
+export function hashFile(filePath) { return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex"); }

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -1,164 +1,43 @@
 import { sortEntries, trendMarker } from "./leaderboard.mjs";
+import { readingTimeMinutes } from "./content-utils.mjs";
 
 export function renderShell({ title, main, activeNav = "/" }) {
-  const nav = [
-    ["/", "Home"],
-    ["/leaderboard", "Leaderboard"],
-    ["/blog", "Blog"],
-    ["/changelog", "Changelog"],
-    ["/rules", "Rules"]
-  ];
+  const nav = [["/", "Home"], ["/leaderboard", "Leaderboard"], ["/blog", "Blog"], ["/changelog", "Changelog"], ["/rules", "Rules"]];
   const navHtml = nav.map(([href, label]) => `<a href="${href}" ${activeNav === href ? "aria-current=\"page\"" : ""}>${label}</a>`).join(" ");
-
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${title}</title>
-  <style>${baseStyles()}</style>
-</head>
-<body>
-  <header>
-    <nav aria-label="Primary">${navHtml}</nav>
-  </header>
-  <main>${main}</main>
-  <footer><small>© Kriegspiel</small></footer>
-</body>
-</html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>${title}</title><style>${baseStyles()}</style></head><body><header><nav aria-label="Primary">${navHtml}</nav></header><main>${main}</main><footer><small>© Kriegspiel</small></footer></body></html>`;
 }
 
 export function renderHomePage({ rulesCount = 0, blogCount = 0 }) {
-  return renderShell({
-    title: "Kriegspiel — Home",
-    activeNav: "/",
-    main: `
-      <section id="hero"><h1>Play hidden-information chess, properly online.</h1>
-        <p>Kriegspiel keeps uncertainty and referee semantics while making games fast and fair.</p>
-        <a href="/leaderboard" data-telemetry-event="home_cta_click">See Leaderboard</a>
-      </section>
-      <section id="how-it-works"><h2>How it works</h2><ol><li>Queue for a match.</li><li>Receive legal/no announcements.</li><li>Review game narrative.</li></ol></section>
-      <section id="key-features"><h2>Key features</h2><ul><li>Asymmetric information preserved.</li><li>Fast async-friendly play.</li><li>Variant-specific referee output.</li></ul></section>
-      <section id="cta"><h2>Ready to play?</h2><a href="/rules">Read rules</a></section>
-      <section id="trust-snippet"><h2>Trust snapshot</h2><p>${rulesCount} rulesets documented, ${blogCount} public updates shipped.</p></section>
-    `
-  });
+  return renderShell({ title: "Kriegspiel — Home", activeNav: "/", main: `<section id="hero"><h1>Play hidden-information chess, properly online.</h1><p>Kriegspiel keeps uncertainty and referee semantics while making games fast and fair.</p><a href="/leaderboard" data-telemetry-event="home_cta_click">See Leaderboard</a></section><section id="how-it-works"><h2>How it works</h2><ol><li>Queue for a match.</li><li>Receive legal/no announcements.</li><li>Review game narrative.</li></ol></section><section id="key-features"><h2>Key features</h2><ul><li>Asymmetric information preserved.</li><li>Fast async-friendly play.</li><li>Variant-specific referee output.</li></ul></section><section id="cta"><h2>Ready to play?</h2><a href="/rules">Read rules</a></section><section id="trust-snippet"><h2>Trust snapshot</h2><p>${rulesCount} rulesets documented, ${blogCount} public updates shipped.</p></section>` });
 }
 
 export function renderLeaderboardPage(entries = []) {
   const sorted = sortEntries(entries, "rating", "desc");
   const rows = sorted.map((entry, i) => `<tr><td>${i + 1}</td><td>${entry.handle}</td><td>${entry.rating}</td><td>${entry.gamesPlayed}</td><td aria-label="trend">${trendMarker(entry.trend)}</td></tr>`).join("");
-
-  return renderShell({
-    title: "Kriegspiel — Leaderboard",
-    activeNav: "/leaderboard",
-    main: `
-      <section>
-        <h1>Leaderboard</h1>
-        <p>Top active players, refreshed from ranking API.</p>
-        <div id="stale-banner" hidden role="status">Showing stale data. Refreshing…</div>
-        <div>
-          <button data-sort="rating" data-telemetry-event="leaderboard_sort">Sort by rating</button>
-          <button data-sort="gamesPlayed" data-telemetry-event="leaderboard_sort">Sort by games</button>
-          <button id="retry" data-telemetry-event="leaderboard_retry">Retry</button>
-        </div>
-        <div id="loading" role="status">Loading leaderboard…</div>
-        <div id="error" hidden role="alert">Could not load leaderboard. Try again.</div>
-        <div id="empty" hidden role="status">No ranked players yet.</div>
-        <table id="leaderboard-table" hidden>
-          <caption>Top players by rating</caption>
-          <thead><tr><th>Rank</th><th>Player</th><th>Rating</th><th>Games</th><th>Trend</th></tr></thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </section>
-      <script>
-        (function(){
-          const state = { entries: [] };
-          const el = {
-            loading: document.getElementById('loading'),
-            error: document.getElementById('error'),
-            empty: document.getElementById('empty'),
-            table: document.getElementById('leaderboard-table'),
-            tbody: document.querySelector('#leaderboard-table tbody'),
-            stale: document.getElementById('stale-banner')
-          };
-
-          function render(kind){
-            el.loading.hidden = kind !== 'loading';
-            el.error.hidden = kind !== 'error';
-            el.empty.hidden = kind !== 'empty';
-            el.table.hidden = kind !== 'ready';
-          }
-
-          function emit(name, detail){
-            window.dispatchEvent(new CustomEvent('telemetry', { detail: { name, ...detail } }));
-          }
-
-          function draw(entries){
-            el.tbody.innerHTML = entries.map((entry, i) => '<tr><td>' + (i + 1) + '</td><td>' + entry.handle + '</td><td>' + entry.rating + '</td><td>' + entry.gamesPlayed + '</td><td>' + (entry.trend === 'up' ? '↑' : entry.trend === 'down' ? '↓' : '→') + '</td></tr>').join('');
-            render(entries.length === 0 ? 'empty' : 'ready');
-          }
-
-          function normalize(payload){
-            if (!payload || !Array.isArray(payload.players)) throw new Error('malformed payload');
-            return payload.players.filter((p) => p && typeof p.handle === 'string' && Number.isFinite(p.rating) && Number.isFinite(p.gamesPlayed)).map((p)=>({
-              handle: p.handle,
-              rating: p.rating,
-              gamesPlayed: p.gamesPlayed,
-              trend: p.trend === 'up' || p.trend === 'down' ? p.trend : 'flat'
-            }));
-          }
-
-          function sortBy(field){
-            state.entries.sort((a,b)=> (b[field]-a[field]) || a.handle.localeCompare(b.handle));
-            draw(state.entries);
-            emit('leaderboard_sort', { field });
-          }
-
-          async function load(){
-            render('loading');
-            try {
-              const res = await fetch('/api/leaderboard', { cache: 'no-store' });
-              if (!res.ok) throw new Error('http');
-              const payload = await res.json();
-              state.entries = normalize(payload);
-              if (payload.updatedAt && (Date.now() - Date.parse(payload.updatedAt)) > (15 * 60 * 1000)) {
-                el.stale.hidden = false;
-              } else {
-                el.stale.hidden = true;
-              }
-              draw(state.entries);
-            } catch (_) {
-              render('error');
-            }
-          }
-
-          document.querySelectorAll('[data-sort]').forEach((btn)=>btn.addEventListener('click', ()=>sortBy(btn.getAttribute('data-sort'))));
-          document.getElementById('retry').addEventListener('click', ()=>{ emit('leaderboard_retry', {}); load(); });
-          load();
-        })();
-      </script>
-    `
-  });
+  return renderShell({ title: "Kriegspiel — Leaderboard", activeNav: "/leaderboard", main: `<section><h1>Leaderboard</h1><p>Top active players, refreshed from ranking API.</p><div id="stale-banner" hidden role="status">Showing stale data. Refreshing…</div><div><button data-sort="rating" data-telemetry-event="leaderboard_sort">Sort by rating</button><button data-sort="gamesPlayed" data-telemetry-event="leaderboard_sort">Sort by games</button><button id="retry" data-telemetry-event="leaderboard_retry">Retry</button></div><div id="loading" role="status">Loading leaderboard…</div><div id="error" hidden role="alert">Could not load leaderboard. Try again.</div><div id="empty" hidden role="status">No ranked players yet.</div><table id="leaderboard-table" hidden><caption>Top players by rating</caption><thead><tr><th>Rank</th><th>Player</th><th>Rating</th><th>Games</th><th>Trend</th></tr></thead><tbody>${rows}</tbody></table></section><script>(function(){const state={entries:[]};const el={loading:document.getElementById('loading'),error:document.getElementById('error'),empty:document.getElementById('empty'),table:document.getElementById('leaderboard-table'),tbody:document.querySelector('#leaderboard-table tbody'),stale:document.getElementById('stale-banner')};function render(kind){el.loading.hidden=kind!=='loading';el.error.hidden=kind!=='error';el.empty.hidden=kind!=='empty';el.table.hidden=kind!=='ready';}function emit(name,detail){window.dispatchEvent(new CustomEvent('telemetry',{detail:{name,...detail}}));}function draw(entries){el.tbody.innerHTML=entries.map((entry,i)=>'<tr><td>'+(i+1)+'</td><td>'+entry.handle+'</td><td>'+entry.rating+'</td><td>'+entry.gamesPlayed+'</td><td>'+(entry.trend==='up'?'↑':entry.trend==='down'?'↓':'→')+'</td></tr>').join('');render(entries.length===0?'empty':'ready');}function normalize(payload){if(!payload||!Array.isArray(payload.players))throw new Error('malformed payload');return payload.players.filter((p)=>p&&typeof p.handle==='string'&&Number.isFinite(p.rating)&&Number.isFinite(p.gamesPlayed)).map((p)=>({handle:p.handle,rating:p.rating,gamesPlayed:p.gamesPlayed,trend:p.trend==='up'||p.trend==='down'?p.trend:'flat'}));}function sortBy(field){state.entries.sort((a,b)=>(b[field]-a[field])||a.handle.localeCompare(b.handle));draw(state.entries);emit('leaderboard_sort',{field});}async function load(){render('loading');try{const res=await fetch('/api/leaderboard',{cache:'no-store'});if(!res.ok)throw new Error('http');const payload=await res.json();state.entries=normalize(payload);if(payload.updatedAt&&(Date.now()-Date.parse(payload.updatedAt))>(15*60*1000)){el.stale.hidden=false;}else{el.stale.hidden=true;}draw(state.entries);}catch(_){render('error');}}document.querySelectorAll('[data-sort]').forEach((btn)=>btn.addEventListener('click',()=>sortBy(btn.getAttribute('data-sort'))));document.getElementById('retry').addEventListener('click',()=>{emit('leaderboard_retry',{});load();});load();})();</script>` });
 }
 
-export function renderSimplePage(title) {
-  return renderShell({ title: `Kriegspiel — ${title}`, main: `<h1>${title}</h1><p>Generated by ks-home build.</p>` });
+export function renderBlogIndex(entries) {
+  const items = entries.map((entry) => `<li><a href="/blog/${entry.metadata.slug}">${entry.metadata.title}</a> <small>${entry.metadata.publishedAt} • ${entry.metadata.author} • ${readingTimeMinutes(entry.body)} min read</small><p>${entry.metadata.summary}</p></li>`).join("");
+  return renderShell({ title: "Kriegspiel — Blog", activeNav: "/blog", main: `<section><h1>Blog</h1><p>Editorial updates from the Kriegspiel team.</p><ul>${items}</ul><p><a href="/blog/archive">Browse archive</a></p></section>` });
 }
 
-function baseStyles() {
-  return `
-    :root { font-family: system-ui, sans-serif; color-scheme: light dark; }
-    body { margin: 0 auto; max-width: 960px; padding: 1rem; line-height: 1.45; }
-    nav { display: flex; flex-wrap: wrap; gap: 0.75rem; }
-    section { margin: 1.5rem 0; }
-    table { width: 100%; border-collapse: collapse; }
-    th, td { border: 1px solid #888; padding: 0.45rem; text-align: left; }
-    @media (max-width: 700px) {
-      nav { gap: 0.5rem; font-size: 0.95rem; }
-      table, thead, tbody, tr, th, td { display: block; }
-      tr { border: 1px solid #777; margin-bottom: 0.6rem; }
-      th { display: none; }
-    }
-  `;
+export const renderBlogDetail = (entry) => renderShell({ title: `Kriegspiel — ${entry.metadata.title}`, activeNav: "/blog", main: `<article><h1>${entry.metadata.title}</h1><p><small>${entry.metadata.publishedAt} • ${entry.metadata.author} • ${readingTimeMinutes(entry.body)} min read</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a href="/blog">Back to blog</a></p></article>` });
+
+export function renderBlogArchive(entries) {
+  const groups = new Map();
+  for (const entry of entries) { const year = String(entry.metadata.publishedAt).slice(0, 4); if (!groups.has(year)) groups.set(year, []); groups.get(year).push(entry); }
+  const html = Array.from(groups.entries()).map(([year, posts]) => `<section><h2>${year}</h2><ul>${posts.map((post) => `<li><a href="/blog/${post.metadata.slug}">${post.metadata.title}</a></li>`).join("")}</ul></section>`).join("");
+  return renderShell({ title: "Kriegspiel — Blog Archive", activeNav: "/blog", main: `<h1>Blog archive</h1>${html}` });
 }
+
+export function renderChangelogIndex(entries) {
+  const items = entries.map((entry) => `<li><a href="/changelog/${entry.metadata.slug}">${entry.metadata.version} — ${entry.metadata.title}</a> <small>${entry.metadata.publishedAt}</small><p>${entry.metadata.summary}</p></li>`).join("");
+  return renderShell({ title: "Kriegspiel — Changelog", activeNav: "/changelog", main: `<section><h1>Changelog</h1><p>Versioned release history.</p><ul>${items}</ul></section>` });
+}
+
+export const renderChangelogDetail = (entry) => renderShell({ title: `Kriegspiel — ${entry.metadata.title}`, activeNav: "/changelog", main: `<article><h1>${entry.metadata.title}</h1><p><small>Version ${entry.metadata.version} • ${entry.metadata.publishedAt}</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a href="/changelog">Back to changelog</a></p></article>` });
+
+export const renderSimplePage = (title) => renderShell({ title: `Kriegspiel — ${title}`, main: `<h1>${title}</h1><p>Generated by ks-home build.</p>` });
+
+function baseStyles() { return `:root{font-family:system-ui,sans-serif;color-scheme:light dark;}body{margin:0 auto;max-width:960px;padding:1rem;line-height:1.45;}nav{display:flex;flex-wrap:wrap;gap:.75rem;}section{margin:1.5rem 0;}table{width:100%;border-collapse:collapse;}th,td{border:1px solid #888;padding:.45rem;text-align:left;}@media (max-width:700px){nav{gap:.5rem;font-size:.95rem;}table,thead,tbody,tr,th,td{display:block;}tr{border:1px solid #777;margin-bottom:.6rem;}th{display:none;}}`; }

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -8,7 +8,7 @@ const distRoot = path.resolve(process.cwd(), "dist");
 
 test("build generates required static routes", () => {
   execSync("node scripts/build.mjs", { stdio: "pipe" });
-  for (const routeFile of ["index.html", "leaderboard/index.html", "blog/index.html", "changelog/index.html", "rules/index.html"]) {
+  for (const routeFile of ["index.html", "leaderboard/index.html", "blog/index.html", "blog/archive/index.html", "blog/welcome/index.html", "changelog/index.html", "changelog/2026-03-27-slice-910/index.html", "rules/index.html"]) {
     assert.ok(fs.existsSync(path.join(distRoot, routeFile)), `missing ${routeFile}`);
   }
 });


### PR DESCRIPTION
Implements slice 930 website-side blog/changelog pipeline:\n- blog index/detail/archive and changelog detail/index rendering\n- content-trigger simulation check\n- sitemap/feed generation checks\n- blog/changelog e2e coverage\n\nValidation run:\n- npm ci\n- npm run test -- --runInBand --watch=false\n- npm run test:e2e -- --grep "blog|changelog"\n- npm run build\n- npm run content:trigger:simulate -- --from=../content --verify-static-regen\n- npm run sitemap:generate -- --check\n- npm run feeds:generate -- --check\n- npm run test:a11y -- --routes=/blog,/changelog\n- npm run test:smoke -- --routes=/blog,/changelog