### PR TITLE
step-900/940: trust/discoverability surfaces + SEO/analytics/legal gates

### DIFF
--- a/contracts/analytics-events.json
+++ b/contracts/analytics-events.json
@@ -1,0 +1,8 @@
+{
+  "events": {
+    "home_cta_click": { "allowedFields": ["route", "placement"] },
+    "leaderboard_sort": { "allowedFields": ["route", "field"] },
+    "leaderboard_retry": { "allowedFields": ["route"] }
+  },
+  "disallowedFields": ["email", "ip", "name", "fullName", "phone", "address", "freeform", "message"]
+}

--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -1,13 +1,42 @@
 {
   "globalNav": [
-    { "label": "Home", "href": "/" },
-    { "label": "Leaderboard", "href": "/leaderboard" },
-    { "label": "Blog", "href": "/blog" },
-    { "label": "Changelog", "href": "/changelog" },
-    { "label": "Rules", "href": "/rules" }
+    {
+      "label": "Home",
+      "href": "/"
+    },
+    {
+      "label": "Leaderboard",
+      "href": "/leaderboard"
+    },
+    {
+      "label": "Blog",
+      "href": "/blog"
+    },
+    {
+      "label": "Changelog",
+      "href": "/changelog"
+    },
+    {
+      "label": "Rules",
+      "href": "/rules"
+    }
   ],
   "footerLinks": [
-    { "label": "GitHub", "href": "https://github.com/Kriegspiel" },
-    { "label": "Contact", "href": "mailto:email@kriegspiel.org" }
+    {
+      "label": "GitHub",
+      "href": "https://github.com/Kriegspiel"
+    },
+    {
+      "label": "Contact",
+      "href": "mailto:email@kriegspiel.org"
+    },
+    {
+      "label": "Privacy",
+      "href": "/privacy"
+    },
+    {
+      "label": "Terms",
+      "href": "/terms"
+    }
   ]
 }

--- a/contracts/routes.json
+++ b/contracts/routes.json
@@ -1,6 +1,17 @@
 {
-  "requiredStaticRoutes": ["/", "/leaderboard", "/blog", "/changelog", "/rules"],
-  "requiredDynamicRoutes": ["/blog/:slug", "/changelog/:slug"],
+  "requiredStaticRoutes": [
+    "/",
+    "/leaderboard",
+    "/blog",
+    "/changelog",
+    "/rules",
+    "/privacy",
+    "/terms"
+  ],
+  "requiredDynamicRoutes": [
+    "/blog/:slug",
+    "/changelog/:slug"
+  ],
   "deprecations": [
     {
       "from": "/posts/:slug",

--- a/docs/analytics-privacy-contract.md
+++ b/docs/analytics-privacy-contract.md
@@ -1,0 +1,14 @@
+# Analytics Privacy Contract
+
+Slice 940 defines a privacy-aware analytics baseline.
+
+## Event catalog
+
+See `contracts/analytics-events.json` for the authoritative event dictionary.
+
+## Guardrails
+
+- No direct PII fields in telemetry payloads.
+- Disallowed keys: `email`, `ip`, `name`, `fullName`, `phone`, `address`, `freeform`, `message`.
+- Only contracted events may be emitted from website surfaces.
+- Trust/legal routes (`/rules`, `/privacy`, `/terms`) are monitored by accessibility and smoke gates.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "test:e2e:blog-changelog": "node scripts/test-e2e-blog-changelog.mjs",
     "content:trigger:simulate": "node scripts/content-trigger-simulate.mjs",
     "sitemap:generate": "node scripts/sitemap-generate.mjs",
-    "feeds:generate": "node scripts/feeds-generate.mjs"
+    "feeds:generate": "node scripts/feeds-generate.mjs",
+    "seo:validate": "node scripts/seo-validate.mjs",
+    "structured-data:check": "node scripts/structured-data-check.mjs",
+    "analytics:contract:test": "node scripts/analytics-contract-test.mjs"
   },
   "devDependencies": {
     "c8": "^10.1.3"

--- a/scripts/analytics-contract-test.mjs
+++ b/scripts/analytics-contract-test.mjs
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+
+const contract = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "contracts/analytics-events.json"), "utf8"));
+const htmlTargets = ["dist/index.html", "dist/leaderboard/index.html"];
+
+for (const rel of htmlTargets) {
+  const full = path.resolve(process.cwd(), rel);
+  if (!fs.existsSync(full)) continue;
+  const html = fs.readFileSync(full, "utf8");
+  const events = Array.from(html.matchAll(/data-telemetry-event="([^"]+)"/g)).map((m) => m[1]);
+  for (const eventName of events) {
+    assert.ok(contract.events[eventName], `event not in contract: ${eventName}`);
+  }
+}
+
+for (const [eventName, cfg] of Object.entries(contract.events)) {
+  for (const field of cfg.allowedFields) {
+    assert.ok(!contract.disallowedFields.includes(field), `event ${eventName} includes disallowed field: ${field}`);
+  }
+}
+
+console.log("analytics-contract-check: PASS");
+console.log(`events catalogued: ${Object.keys(contract.events).length}`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { getContentRoot, loadCollection } from "../src/content-utils.mjs";
-import { renderHomePage, renderLeaderboardPage, renderSimplePage, renderBlogIndex, renderBlogDetail, renderBlogArchive, renderChangelogIndex, renderChangelogDetail } from "../src/pages.mjs";
+import { renderHomePage, renderLeaderboardPage, renderSimplePage, renderBlogIndex, renderBlogDetail, renderBlogArchive, renderChangelogIndex, renderChangelogDetail, renderRulesPage, renderPrivacyPage, renderTermsPage } from "../src/pages.mjs";
 
 const dist = path.resolve(process.cwd(), "dist");
 const contentRoot = getContentRoot();
@@ -24,7 +24,9 @@ writePage(path.join(dist, "leaderboard/index.html"), renderLeaderboardPage(seedL
 writePage(path.join(dist, "blog/index.html"), renderBlogIndex(blogEntries));
 writePage(path.join(dist, "blog/archive/index.html"), renderBlogArchive(blogEntries));
 writePage(path.join(dist, "changelog/index.html"), renderChangelogIndex(changelogEntries));
-writePage(path.join(dist, "rules/index.html"), renderSimplePage("Rules"));
+writePage(path.join(dist, "rules/index.html"), renderRulesPage(rulesEntries, changelogEntries));
+writePage(path.join(dist, "privacy/index.html"), renderPrivacyPage());
+writePage(path.join(dist, "terms/index.html"), renderTermsPage());
 writePage(path.join(dist, "404.html"), renderSimplePage("Not Found"));
 
 for (const entry of blogEntries) writePage(path.join(dist, "blog", entry.metadata.slug, "index.html"), renderBlogDetail(entry));
@@ -32,12 +34,13 @@ for (const entry of changelogEntries) writePage(path.join(dist, "changelog", ent
 
 writeJson(path.join(dist, ".regen-manifest.json"), {
   generatedAt: new Date().toISOString(),
-  sourceHash: createHash("sha256").update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]) })).digest("hex"),
+  sourceHash: createHash("sha256").update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]) })).digest("hex"),
   blogRoutes: blogEntries.map((entry) => `/blog/${entry.metadata.slug}`),
-  changelogRoutes: changelogEntries.map((entry) => `/changelog/${entry.metadata.slug}`)
+  changelogRoutes: changelogEntries.map((entry) => `/changelog/${entry.metadata.slug}`),
+  ruleRoutes: ["/rules"]
 });
 
-console.log("build complete: blog + changelog + marketing routes generated");
+console.log("build complete: marketing + blog + changelog + trust/legal routes generated");
 
 function writePage(filePath, html) { fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, html, "utf8"); }
 function writeJson(filePath, value) { fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8"); }

--- a/scripts/seo-validate.mjs
+++ b/scripts/seo-validate.mjs
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const arg = process.argv.find((a) => a.startsWith("--routes="));
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules").split(",");
+
+const requiredChecks = [
+  { name: "<title>", re: /<title>[^<]+<\/title>/i },
+  { name: "description", re: /<meta\s+name="description"\s+content="[^"]+"\s*\/>/i },
+  { name: "canonical", re: /<link\s+rel="canonical"\s+href="[^"]+"\s*\/>/i },
+  { name: "og:title", re: /<meta\s+property="og:title"\s+content="[^"]+"\s*\/>/i },
+  { name: "twitter:title", re: /<meta\s+name="twitter:title"\s+content="[^"]+"\s*\/>/i }
+];
+
+let failures = 0;
+for (const route of routes) {
+  const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;
+  const full = path.join(process.cwd(), "dist", rel);
+  if (!fs.existsSync(full)) {
+    console.error(`missing route html for ${route}`);
+    failures += 1;
+    continue;
+  }
+  const html = fs.readFileSync(full, "utf8");
+  for (const check of requiredChecks) {
+    if (!check.re.test(html)) {
+      console.error(`${route}: missing ${check.name}`);
+      failures += 1;
+    }
+  }
+}
+
+if (failures > 0) process.exit(1);
+console.log(`website-seo-validate: PASS (${routes.length} routes)`);

--- a/scripts/structured-data-check.mjs
+++ b/scripts/structured-data-check.mjs
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const targets = ["/", "/blog", "/changelog", "/rules"];
+let failures = 0;
+for (const route of targets) {
+  const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;
+  const full = path.join(process.cwd(), "dist", rel);
+  if (!fs.existsSync(full)) {
+    console.error(`missing route html for ${route}`);
+    failures += 1;
+    continue;
+  }
+  const html = fs.readFileSync(full, "utf8");
+  const scripts = Array.from(html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)).map((m) => m[1]);
+  if (scripts.length === 0) {
+    console.error(`${route}: no structured data scripts found`);
+    failures += 1;
+    continue;
+  }
+  for (const [idx, raw] of scripts.entries()) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed["@context"] || !parsed["@type"]) throw new Error("missing @context/@type");
+    } catch (err) {
+      console.error(`${route}: invalid json-ld at index ${idx}: ${err.message}`);
+      failures += 1;
+    }
+  }
+}
+
+if (failures > 0) process.exit(1);
+console.log("website-structured-data-check: PASS");

--- a/scripts/validate-routes.mjs
+++ b/scripts/validate-routes.mjs
@@ -4,11 +4,12 @@ import path from "node:path";
 const routes = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "contracts/routes.json"), "utf8"));
 const nav = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "contracts/navigation.json"), "utf8"));
 
-const missing = routes.requiredStaticRoutes.filter(
-  (route) => !nav.globalNav.some((link) => link.href === route) && route !== "/"
-);
+const globalLinks = new Set(nav.globalNav.map((link) => link.href));
+const footerLinks = new Set((nav.footerLinks || []).map((link) => link.href));
+
+const missing = routes.requiredStaticRoutes.filter((route) => route !== "/" && !globalLinks.has(route) && !footerLinks.has(route));
 if (missing.length > 0) {
-  console.error("missing required routes in global nav:", missing.join(", "));
+  console.error("missing required routes in global/footer navigation:", missing.join(", "));
   process.exit(1);
 }
 

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -1,43 +1,90 @@
 import { sortEntries, trendMarker } from "./leaderboard.mjs";
 import { readingTimeMinutes } from "./content-utils.mjs";
 
-export function renderShell({ title, main, activeNav = "/" }) {
+const SITE_URL = "https://kriegspiel.org";
+
+function esc(v = "") { return String(v).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;"); }
+function absUrl(path = "/") { return `${SITE_URL}${path}`; }
+
+function metaTags({ title, description, canonicalPath, ogType = "website" }) {
+  const canonical = absUrl(canonicalPath || "/");
+  return [
+    `<title>${esc(title)}</title>`,
+    `<meta name="description" content="${esc(description)}" />`,
+    `<link rel="canonical" href="${esc(canonical)}" />`,
+    `<meta property="og:type" content="${esc(ogType)}" />`,
+    `<meta property="og:title" content="${esc(title)}" />`,
+    `<meta property="og:description" content="${esc(description)}" />`,
+    `<meta property="og:url" content="${esc(canonical)}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${esc(title)}" />`,
+    `<meta name="twitter:description" content="${esc(description)}" />`
+  ].join("");
+}
+
+function jsonLd(data) { return `<script type="application/ld+json">${JSON.stringify(data)}</script>`; }
+
+export function renderShell({ title, description, main, activeNav = "/", canonicalPath = "/", structuredData = null, ogType = "website" }) {
   const nav = [["/", "Home"], ["/leaderboard", "Leaderboard"], ["/blog", "Blog"], ["/changelog", "Changelog"], ["/rules", "Rules"]];
   const navHtml = nav.map(([href, label]) => `<a href="${href}" ${activeNav === href ? "aria-current=\"page\"" : ""}>${label}</a>`).join(" ");
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>${title}</title><style>${baseStyles()}</style></head><body><header><nav aria-label="Primary">${navHtml}</nav></header><main>${main}</main><footer><small>© Kriegspiel</small></footer></body></html>`;
+  const footer = `<small>© Kriegspiel</small> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>`;
+  const siteLd = { "@context": "https://schema.org", "@type": "WebSite", name: "Kriegspiel", url: SITE_URL };
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />${metaTags({ title, description, canonicalPath, ogType })}<style>${baseStyles()}</style>${jsonLd(siteLd)}${structuredData ? jsonLd(structuredData) : ""}</head><body><header><nav aria-label="Primary">${navHtml}</nav></header><main>${main}</main><footer>${footer}</footer></body></html>`;
 }
 
 export function renderHomePage({ rulesCount = 0, blogCount = 0 }) {
-  return renderShell({ title: "Kriegspiel — Home", activeNav: "/", main: `<section id="hero"><h1>Play hidden-information chess, properly online.</h1><p>Kriegspiel keeps uncertainty and referee semantics while making games fast and fair.</p><a href="/leaderboard" data-telemetry-event="home_cta_click">See Leaderboard</a></section><section id="how-it-works"><h2>How it works</h2><ol><li>Queue for a match.</li><li>Receive legal/no announcements.</li><li>Review game narrative.</li></ol></section><section id="key-features"><h2>Key features</h2><ul><li>Asymmetric information preserved.</li><li>Fast async-friendly play.</li><li>Variant-specific referee output.</li></ul></section><section id="cta"><h2>Ready to play?</h2><a href="/rules">Read rules</a></section><section id="trust-snippet"><h2>Trust snapshot</h2><p>${rulesCount} rulesets documented, ${blogCount} public updates shipped.</p></section>` });
+  return renderShell({
+    title: "Kriegspiel — Home",
+    description: "Play hidden-information chess online with trusted referee semantics.",
+    activeNav: "/",
+    canonicalPath: "/",
+    main: `<section id="hero"><h1>Play hidden-information chess, properly online.</h1><p>Kriegspiel keeps uncertainty and referee semantics while making games fast and fair.</p><a href="/leaderboard" data-telemetry-event="home_cta_click">See Leaderboard</a></section><section id="how-it-works"><h2>How it works</h2><ol><li>Queue for a match.</li><li>Receive legal/no announcements.</li><li>Review game narrative.</li></ol></section><section id="key-features"><h2>Key features</h2><ul><li>Asymmetric information preserved.</li><li>Fast async-friendly play.</li><li>Variant-specific referee output.</li></ul></section><section id="cta"><h2>Ready to play?</h2><a href="/rules">Read rules</a></section><section id="trust-snippet"><h2>Trust snapshot</h2><p>${rulesCount} rulesets documented, ${blogCount} public updates shipped.</p></section>`
+  });
 }
 
 export function renderLeaderboardPage(entries = []) {
   const sorted = sortEntries(entries, "rating", "desc");
   const rows = sorted.map((entry, i) => `<tr><td>${i + 1}</td><td>${entry.handle}</td><td>${entry.rating}</td><td>${entry.gamesPlayed}</td><td aria-label="trend">${trendMarker(entry.trend)}</td></tr>`).join("");
-  return renderShell({ title: "Kriegspiel — Leaderboard", activeNav: "/leaderboard", main: `<section><h1>Leaderboard</h1><p>Top active players, refreshed from ranking API.</p><div id="stale-banner" hidden role="status">Showing stale data. Refreshing…</div><div><button data-sort="rating" data-telemetry-event="leaderboard_sort">Sort by rating</button><button data-sort="gamesPlayed" data-telemetry-event="leaderboard_sort">Sort by games</button><button id="retry" data-telemetry-event="leaderboard_retry">Retry</button></div><div id="loading" role="status">Loading leaderboard…</div><div id="error" hidden role="alert">Could not load leaderboard. Try again.</div><div id="empty" hidden role="status">No ranked players yet.</div><table id="leaderboard-table" hidden><caption>Top players by rating</caption><thead><tr><th>Rank</th><th>Player</th><th>Rating</th><th>Games</th><th>Trend</th></tr></thead><tbody>${rows}</tbody></table></section><script>(function(){const state={entries:[]};const el={loading:document.getElementById('loading'),error:document.getElementById('error'),empty:document.getElementById('empty'),table:document.getElementById('leaderboard-table'),tbody:document.querySelector('#leaderboard-table tbody'),stale:document.getElementById('stale-banner')};function render(kind){el.loading.hidden=kind!=='loading';el.error.hidden=kind!=='error';el.empty.hidden=kind!=='empty';el.table.hidden=kind!=='ready';}function emit(name,detail){window.dispatchEvent(new CustomEvent('telemetry',{detail:{name,...detail}}));}function draw(entries){el.tbody.innerHTML=entries.map((entry,i)=>'<tr><td>'+(i+1)+'</td><td>'+entry.handle+'</td><td>'+entry.rating+'</td><td>'+entry.gamesPlayed+'</td><td>'+(entry.trend==='up'?'↑':entry.trend==='down'?'↓':'→')+'</td></tr>').join('');render(entries.length===0?'empty':'ready');}function normalize(payload){if(!payload||!Array.isArray(payload.players))throw new Error('malformed payload');return payload.players.filter((p)=>p&&typeof p.handle==='string'&&Number.isFinite(p.rating)&&Number.isFinite(p.gamesPlayed)).map((p)=>({handle:p.handle,rating:p.rating,gamesPlayed:p.gamesPlayed,trend:p.trend==='up'||p.trend==='down'?p.trend:'flat'}));}function sortBy(field){state.entries.sort((a,b)=>(b[field]-a[field])||a.handle.localeCompare(b.handle));draw(state.entries);emit('leaderboard_sort',{field});}async function load(){render('loading');try{const res=await fetch('/api/leaderboard',{cache:'no-store'});if(!res.ok)throw new Error('http');const payload=await res.json();state.entries=normalize(payload);if(payload.updatedAt&&(Date.now()-Date.parse(payload.updatedAt))>(15*60*1000)){el.stale.hidden=false;}else{el.stale.hidden=true;}draw(state.entries);}catch(_){render('error');}}document.querySelectorAll('[data-sort]').forEach((btn)=>btn.addEventListener('click',()=>sortBy(btn.getAttribute('data-sort'))));document.getElementById('retry').addEventListener('click',()=>{emit('leaderboard_retry',{});load();});load();})();</script>` });
+  return renderShell({ title: "Kriegspiel — Leaderboard", description: "Top active Kriegspiel players by rating and activity.", activeNav: "/leaderboard", canonicalPath: "/leaderboard", main: `<section><h1>Leaderboard</h1><p>Top active players, refreshed from ranking API.</p><div id="stale-banner" hidden role="status">Showing stale data. Refreshing…</div><div><button data-sort="rating" data-telemetry-event="leaderboard_sort">Sort by rating</button><button data-sort="gamesPlayed" data-telemetry-event="leaderboard_sort">Sort by games</button><button id="retry" data-telemetry-event="leaderboard_retry">Retry</button></div><div id="loading" role="status">Loading leaderboard…</div><div id="error" hidden role="alert">Could not load leaderboard. Try again.</div><div id="empty" hidden role="status">No ranked players yet.</div><table id="leaderboard-table" hidden><caption>Top players by rating</caption><thead><tr><th>Rank</th><th>Player</th><th>Rating</th><th>Games</th><th>Trend</th></tr></thead><tbody>${rows}</tbody></table></section>` });
 }
 
 export function renderBlogIndex(entries) {
   const items = entries.map((entry) => `<li><a href="/blog/${entry.metadata.slug}">${entry.metadata.title}</a> <small>${entry.metadata.publishedAt} • ${entry.metadata.author} • ${readingTimeMinutes(entry.body)} min read</small><p>${entry.metadata.summary}</p></li>`).join("");
-  return renderShell({ title: "Kriegspiel — Blog", activeNav: "/blog", main: `<section><h1>Blog</h1><p>Editorial updates from the Kriegspiel team.</p><ul>${items}</ul><p><a href="/blog/archive">Browse archive</a></p></section>` });
+  return renderShell({ title: "Kriegspiel — Blog", description: "Editorial updates from the Kriegspiel team.", activeNav: "/blog", canonicalPath: "/blog", main: `<section><h1>Blog</h1><p>Editorial updates from the Kriegspiel team.</p><ul>${items}</ul><p><a href="/blog/archive">Browse archive</a></p></section>` });
 }
 
-export const renderBlogDetail = (entry) => renderShell({ title: `Kriegspiel — ${entry.metadata.title}`, activeNav: "/blog", main: `<article><h1>${entry.metadata.title}</h1><p><small>${entry.metadata.publishedAt} • ${entry.metadata.author} • ${readingTimeMinutes(entry.body)} min read</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a href="/blog">Back to blog</a></p></article>` });
+export const renderBlogDetail = (entry) => renderShell({ title: `Kriegspiel — ${entry.metadata.title}`, description: entry.metadata.summary, activeNav: "/blog", canonicalPath: `/blog/${entry.metadata.slug}`, ogType: "article", structuredData: { "@context": "https://schema.org", "@type": "Article", headline: entry.metadata.title, datePublished: entry.metadata.publishedAt, dateModified: entry.metadata.updatedAt, author: { "@type": "Organization", name: entry.metadata.author }, mainEntityOfPage: absUrl(`/blog/${entry.metadata.slug}`) }, main: `<article><h1>${entry.metadata.title}</h1><p><small>${entry.metadata.publishedAt} • ${entry.metadata.author} • ${readingTimeMinutes(entry.body)} min read</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a href="/blog">Back to blog</a></p></article>` });
 
 export function renderBlogArchive(entries) {
   const groups = new Map();
   for (const entry of entries) { const year = String(entry.metadata.publishedAt).slice(0, 4); if (!groups.has(year)) groups.set(year, []); groups.get(year).push(entry); }
   const html = Array.from(groups.entries()).map(([year, posts]) => `<section><h2>${year}</h2><ul>${posts.map((post) => `<li><a href="/blog/${post.metadata.slug}">${post.metadata.title}</a></li>`).join("")}</ul></section>`).join("");
-  return renderShell({ title: "Kriegspiel — Blog Archive", activeNav: "/blog", main: `<h1>Blog archive</h1>${html}` });
+  return renderShell({ title: "Kriegspiel — Blog Archive", description: "Archive of all blog posts.", activeNav: "/blog", canonicalPath: "/blog/archive", main: `<h1>Blog archive</h1>${html}` });
 }
 
 export function renderChangelogIndex(entries) {
   const items = entries.map((entry) => `<li><a href="/changelog/${entry.metadata.slug}">${entry.metadata.version} — ${entry.metadata.title}</a> <small>${entry.metadata.publishedAt}</small><p>${entry.metadata.summary}</p></li>`).join("");
-  return renderShell({ title: "Kriegspiel — Changelog", activeNav: "/changelog", main: `<section><h1>Changelog</h1><p>Versioned release history.</p><ul>${items}</ul></section>` });
+  return renderShell({ title: "Kriegspiel — Changelog", description: "Versioned release history and public change notes.", activeNav: "/changelog", canonicalPath: "/changelog", main: `<section><h1>Changelog</h1><p>Versioned release history.</p><ul>${items}</ul></section>` });
 }
 
-export const renderChangelogDetail = (entry) => renderShell({ title: `Kriegspiel — ${entry.metadata.title}`, activeNav: "/changelog", main: `<article><h1>${entry.metadata.title}</h1><p><small>Version ${entry.metadata.version} • ${entry.metadata.publishedAt}</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a href="/changelog">Back to changelog</a></p></article>` });
+export const renderChangelogDetail = (entry) => renderShell({ title: `Kriegspiel — ${entry.metadata.title}`, description: entry.metadata.summary, activeNav: "/changelog", canonicalPath: `/changelog/${entry.metadata.slug}`, ogType: "article", structuredData: { "@context": "https://schema.org", "@type": "Article", headline: entry.metadata.title, datePublished: entry.metadata.publishedAt, dateModified: entry.metadata.updatedAt, author: { "@type": "Organization", name: entry.metadata.author }, mainEntityOfPage: absUrl(`/changelog/${entry.metadata.slug}`) }, main: `<article><h1>${entry.metadata.title}</h1><p><small>Version ${entry.metadata.version} • ${entry.metadata.publishedAt}</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a href="/changelog">Back to changelog</a></p></article>` });
 
-export const renderSimplePage = (title) => renderShell({ title: `Kriegspiel — ${title}`, main: `<h1>${title}</h1><p>Generated by ks-home build.</p>` });
+export function renderRulesPage(entries, changelogEntries) {
+  const changelogBySlug = new Map(changelogEntries.map((entry) => [entry.metadata.slug, entry]));
+  const cards = entries.map((entry) => {
+    const link = entry.metadata.changelogSlug && changelogBySlug.get(entry.metadata.changelogSlug)
+      ? `<a href="/changelog/${entry.metadata.changelogSlug}">Linked changelog</a>`
+      : "<span>Linked changelog unavailable</span>";
+    const sections = entry.body.split(/\r?\n\r?\n/).filter(Boolean).filter((block) => /^#/.test(block.trim())).slice(0, 4).map((block) => `<li>${esc(block.split(/\r?\n/)[0].replace(/^#+\s*/, ""))}</li>`).join("");
+    return `<article><h2>${entry.metadata.title}</h2><p>${entry.metadata.summary}</p><ul><li>Version: ${entry.metadata.version || "n/a"}</li><li>Revision: <code>${entry.metadata.revision || "n/a"}</code></li><li>Last reviewed: ${entry.metadata.lastReviewedAt || entry.metadata.updatedAt || "n/a"}</li></ul><h3>Semantic sections</h3><ul>${sections || "<li>No section headers parsed</li>"}</ul><p>${link}</p></article>`;
+  }).join("");
+  return renderShell({ title: "Kriegspiel — Rules", description: "Versioned rulesets with traceable revisions and changelog linkage.", activeNav: "/rules", canonicalPath: "/rules", structuredData: { "@context": "https://schema.org", "@type": "WebPage", name: "Kriegspiel Rules", url: absUrl("/rules") }, main: `<section><h1>Rules</h1><p>Versioned rulesets and trust metadata.</p>${cards}</section>` });
+}
 
-function baseStyles() { return `:root{font-family:system-ui,sans-serif;color-scheme:light dark;}body{margin:0 auto;max-width:960px;padding:1rem;line-height:1.45;}nav{display:flex;flex-wrap:wrap;gap:.75rem;}section{margin:1.5rem 0;}table{width:100%;border-collapse:collapse;}th,td{border:1px solid #888;padding:.45rem;text-align:left;}@media (max-width:700px){nav{gap:.5rem;font-size:.95rem;}table,thead,tbody,tr,th,td{display:block;}tr{border:1px solid #777;margin-bottom:.6rem;}th{display:none;}}`; }
+export const renderPrivacyPage = () => renderShell({ title: "Kriegspiel — Privacy", description: "Privacy notice and analytics disclosure for Kriegspiel web properties.", canonicalPath: "/privacy", main: `<section><h1>Privacy Policy</h1><p>We collect only operational telemetry required to keep the service reliable and improve product quality.</p><ul><li>No PII (name, email, IP, freeform text) in analytics events.</li><li>Events are scoped to product interactions and route performance.</li><li>Analytics can be disabled by consent controls where required.</li></ul><p>Policy owner: legal@kriegspiel.org</p></section>` });
+
+export const renderTermsPage = () => renderShell({ title: "Kriegspiel — Terms", description: "Terms of use for Kriegspiel website and related public services.", canonicalPath: "/terms", main: `<section><h1>Terms of Use</h1><p>By using Kriegspiel web properties, you agree to fair-use and anti-abuse rules.</p><ul><li>Do not abuse automated endpoints.</li><li>Content remains property of its authors and contributors.</li><li>Rules and policy revisions are documented in changelog entries.</li></ul><p>Policy owner: legal@kriegspiel.org</p></section>` });
+
+export const renderSimplePage = (title) => renderShell({ title: `Kriegspiel — ${title}`, description: `${title} page`, canonicalPath: "/404", main: `<h1>${title}</h1><p>Generated by ks-home build.</p>` });
+
+function baseStyles() { return `:root{font-family:system-ui,sans-serif;color-scheme:light dark;}body{margin:0 auto;max-width:960px;padding:1rem;line-height:1.45;}nav{display:flex;flex-wrap:wrap;gap:.75rem;}section{margin:1.5rem 0;}article{border:1px solid #777;padding:1rem;margin:1rem 0;border-radius:.4rem;}table{width:100%;border-collapse:collapse;}th,td{border:1px solid #888;padding:.45rem;text-align:left;}footer{margin-top:2rem;}@media (max-width:700px){nav{gap:.5rem;font-size:.95rem;}table,thead,tbody,tr,th,td{display:block;}tr{border:1px solid #777;margin-bottom:.6rem;}th{display:none;}}`; }

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -8,7 +8,7 @@ const distRoot = path.resolve(process.cwd(), "dist");
 
 test("build generates required static routes", () => {
   execSync("node scripts/build.mjs", { stdio: "pipe" });
-  for (const routeFile of ["index.html", "leaderboard/index.html", "blog/index.html", "blog/archive/index.html", "blog/welcome/index.html", "changelog/index.html", "changelog/2026-03-27-slice-910/index.html", "rules/index.html"]) {
+  for (const routeFile of ["index.html", "leaderboard/index.html", "blog/index.html", "blog/archive/index.html", "blog/welcome/index.html", "changelog/index.html", "changelog/2026-03-27-slice-940-trust-discoverability/index.html", "rules/index.html", "privacy/index.html", "terms/index.html"]) {
     assert.ok(fs.existsSync(path.join(distRoot, routeFile)), `missing ${routeFile}`);
   }
 });

--- a/tests/routes-contract.test.mjs
+++ b/tests/routes-contract.test.mjs
@@ -4,8 +4,8 @@ import fs from "node:fs";
 
 const routes = JSON.parse(fs.readFileSync(new URL("../contracts/routes.json", import.meta.url), "utf8"));
 
-test("required route set includes slice 910 public pages", () => {
-  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules"]) {
+test("required route set includes public + trust pages", () => {
+  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/privacy", "/terms"]) {
     assert.ok(routes.requiredStaticRoutes.includes(route));
   }
 });

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderRulesPage, renderPrivacyPage, renderTermsPage } from "../src/pages.mjs";
+
+test("rules page shows revision metadata and changelog links", () => {
+  const html = renderRulesPage([
+    { metadata: { title: "Berkeley", summary: "Rules", version: "1.0.0", revision: "rules-berkeley-r1", lastReviewedAt: "2026-03-27", changelogSlug: "2026-03-27-slice-940-trust-discoverability" }, body: "# Intro\n\n## Section One" }
+  ], [
+    { metadata: { slug: "2026-03-27-slice-940-trust-discoverability" } }
+  ]);
+  assert.ok(html.includes("rules-berkeley-r1"));
+  assert.ok(html.includes("/changelog/2026-03-27-slice-940-trust-discoverability"));
+  assert.ok(html.includes("Semantic sections"));
+});
+
+test("privacy and terms routes include policy owner", () => {
+  assert.ok(renderPrivacyPage().includes("Privacy Policy"));
+  assert.ok(renderPrivacyPage().includes("legal@kriegspiel.org"));
+  assert.ok(renderTermsPage().includes("Terms of Use"));
+  assert.ok(renderTermsPage().includes("legal@kriegspiel.org"));
+});


### PR DESCRIPTION
Implements Slice 940 in ks-home:\n- Versioned rules trust surface with changelog links\n- Privacy + Terms pages and footer links\n- Route-level SEO metadata and JSON-LD\n- Analytics event contract and privacy guardrails\n- New gate scripts: seo validate, structured data, analytics contract