### PR TITLE
feat: add production static server for ks-home

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,7 @@ npm run routes:validate
 npm run content:schema:check
 npm run content:source-contract:check
 npm run build
+npm run serve:prod -- --host 127.0.0.1 --port 4180
 ```
+
+The production deployment on rpi-server-02 serves the generated `dist/` output directly via `npm run serve:prod`; it does not use Vite preview.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "feeds:generate": "node scripts/feeds-generate.mjs",
     "seo:validate": "node scripts/seo-validate.mjs",
     "structured-data:check": "node scripts/structured-data-check.mjs",
-    "analytics:contract:test": "node scripts/analytics-contract-test.mjs"
+    "analytics:contract:test": "node scripts/analytics-contract-test.mjs",
+    "serve:prod": "node scripts/serve-static.mjs"
   },
   "devDependencies": {
     "c8": "^10.1.3"

--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -1,0 +1,117 @@
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+
+const MIME_TYPES = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".xml", "application/xml; charset=utf-8"],
+  [".txt", "text/plain; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".webp", "image/webp"],
+  [".gif", "image/gif"],
+  [".ico", "image/x-icon"]
+]);
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (!arg.startsWith("--")) continue;
+  const key = arg.slice(2);
+  const next = process.argv[i + 1];
+  if (!next || next.startsWith("--")) {
+    args.set(key, true);
+  } else {
+    args.set(key, next);
+    i += 1;
+  }
+}
+
+const host = String(args.get("host") || process.env.HOST || "127.0.0.1");
+const port = Number(args.get("port") || process.env.PORT || 4180);
+const root = path.resolve(String(args.get("root") || process.env.DIST_DIR || "dist"));
+
+if (!fs.existsSync(root)) {
+  console.error(`Static root not found: ${root}`);
+  process.exit(1);
+}
+
+const server = http.createServer((req, res) => {
+  try {
+    const method = req.method || "GET";
+    if (method !== "GET" && method !== "HEAD") {
+      res.writeHead(405, { "Content-Type": "text/plain; charset=utf-8", Allow: "GET, HEAD" });
+      res.end("Method Not Allowed\n");
+      return;
+    }
+
+    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+    let pathname = decodeURIComponent(url.pathname);
+    if (pathname.includes("\0")) throw new Error("invalid path");
+
+    let filePath = resolvePath(pathname);
+    if (!filePath) {
+      filePath = path.join(root, "404.html");
+      if (!fs.existsSync(filePath)) {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end(method === "HEAD" ? undefined : "Not Found\n");
+        return;
+      }
+      return sendFile(filePath, 404, method, res);
+    }
+
+    sendFile(filePath, 200, method, res);
+  } catch {
+    res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Bad Request\n");
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`Serving ${root} at http://${host}:${port}`);
+});
+
+function resolvePath(pathname) {
+  const candidates = [];
+  if (pathname.endsWith("/")) {
+    candidates.push(path.join(root, pathname, "index.html"));
+  } else {
+    candidates.push(path.join(root, pathname));
+    candidates.push(path.join(root, `${pathname}.html`));
+    candidates.push(path.join(root, pathname, "index.html"));
+  }
+
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate);
+    if (!resolved.startsWith(root + path.sep) && resolved !== root) continue;
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) return resolved;
+  }
+  return null;
+}
+
+function sendFile(filePath, status, method, res) {
+  const stat = fs.statSync(filePath);
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = MIME_TYPES.get(ext) || "application/octet-stream";
+  res.writeHead(status, {
+    "Content-Type": contentType,
+    "Content-Length": stat.size,
+    "Cache-Control": cacheControlFor(filePath)
+  });
+  if (method === "HEAD") {
+    res.end();
+    return;
+  }
+  fs.createReadStream(filePath).pipe(res);
+}
+
+function cacheControlFor(filePath) {
+  return filePath.endsWith(".html") || filePath.endsWith(".json")
+    ? "public, max-age=60"
+    : "public, max-age=300";
+}


### PR DESCRIPTION
## Summary\n- add a tiny Node static server for generated ks-home dist output\n- expose it as npm run serve:prod for production/systemd usage\n- document the intended production serving path\n\n## Testing\n- npm run lint\n- npm test -- --runInBand --watch=false\n- npm run build\n- npm run test:smoke -- --routes=/,/leaderboard,/rules\n- curl -I http://127.0.0.1:4180/{,/leaderboard/,/rules/} via scripts/serve-static.mjs\n