### PR TITLE
Make static leaderboard human only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -147,7 +147,6 @@ async function loadLeaderboardEntriesFromApi() {
     profilePath: player.profile_path || `/players/${player.username}`,
     rating: Number(player.elo || 1200),
     gamesPlayed: Number(player.games_played || 0),
-    trend: 'flat',
     isBot: Boolean(player.is_bot),
   }));
 }

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 
-import { sortEntries, trendMarker } from './leaderboard.mjs';
+import { sortEntries } from './leaderboard.mjs';
 import { readingTimeMinutes } from './content-utils.mjs';
 
 const SITE_URL = 'https://kriegspiel.org';
@@ -137,15 +137,13 @@ export function renderHomePage({ rulesCount = 0, blogCount = 0, homeContent, foo
 }
 
 export function renderLeaderboardPage(entries = [], footerEntry = null, generatedAt = new Date().toISOString()) {
-  const sorted = sortEntries(entries, 'rating', 'desc');
+  const sorted = sortEntries(entries.filter((entry) => !entry.isBot), 'rating', 'desc');
   const rows = sorted.map((entry, i) => {
-    const label = entry.label || entry.handle;
-    const badge = entry.isBot ? ' <small>(bot)</small>' : '';
-    const playerCell = `${esc(label)}${badge}`;
-    return `<tr><td>${i + 1}</td><td>${playerCell}</td><td>${entry.rating}</td><td>${entry.gamesPlayed}</td><td aria-label="trend">${trendMarker(entry.trend)}</td></tr>`;
+    const playerCell = esc(entry.label || entry.handle);
+    return `<tr><td>${i + 1}</td><td>${playerCell}</td><td>${entry.rating}</td><td>${entry.gamesPlayed}</td></tr>`;
   }).join('');
   const updatedAtLabel = formatUtcTimestamp(generatedAt);
-  return renderShell({ footerEntry, title: 'Kriegspiel — Leaderboard', description: 'Top active players and listed bots by rating and activity.', activeNav: '/leaderboard', canonicalPath: '/leaderboard', main: `<section class="content-section"><div class="section-heading"><h1>Leaderboard</h1><p>Top active players and listed bots, refreshed hourly from the ranking API into a static snapshot.</p></div><div class="table-wrap"><table id="leaderboard-table"><caption>Top players by rating</caption><thead><tr><th>Rank</th><th>Player</th><th>Rating</th><th>Games</th><th>Trend</th></tr></thead><tbody>${rows}</tbody></table></div><p class="page-meta-stamp">More detailed and more recent leaderboard: <a class="text-link" href="https://app.kriegspiel.org/leaderboard">app.kriegspiel.org/leaderboard</a></p><p class="page-meta-stamp">Static snapshot updated ${updatedAtLabel}</p></section>` });
+  return renderShell({ footerEntry, title: 'Kriegspiel — Leaderboard', description: 'Top human players by overall rating.', activeNav: '/leaderboard', canonicalPath: '/leaderboard', main: `<section class="content-section"><div class="section-heading"><h1>Leaderboard</h1><p>Top human players by overall rating, refreshed hourly into a static snapshot.</p></div><div class="table-wrap"><table id="leaderboard-table"><caption>Top human players by overall rating</caption><thead><tr><th>Rank</th><th>Player</th><th>Overall rating</th><th>Games</th></tr></thead><tbody>${rows}</tbody></table></div><p class="page-meta-stamp">More detailed and more recent leaderboard: <a class="text-link" href="https://app.kriegspiel.org/leaderboard">app.kriegspiel.org/leaderboard</a></p><p class="page-meta-stamp">Static snapshot updated ${updatedAtLabel}</p></section>` });
 }
 
 export function renderPublicProfilePage({ profile, games = [], footerEntry = null }) {

--- a/tests/home-leaderboard-pages.test.mjs
+++ b/tests/home-leaderboard-pages.test.mjs
@@ -67,7 +67,7 @@ test("home page keeps a simplified play-first layout with CTA telemetry", () => 
 });
 
 test("leaderboard page includes resilient state containers, telemetry hooks, and shared play CTA", () => {
-  const html = renderLeaderboardPage([{ handle: "A", label: "A", profilePath: "/players/a", rating: 10, gamesPlayed: 1, trend: "up", isBot: true }]);
+  const html = renderLeaderboardPage([{ handle: "A", label: "A", profilePath: "/players/a", rating: 10, gamesPlayed: 1, isBot: false }]);
   assert.ok(html.includes('id="leaderboard-table"'));
   assert.ok(!html.includes('Loading leaderboard…'));
   assert.ok(!html.includes('Sort by rating'));
@@ -77,7 +77,9 @@ test("leaderboard page includes resilient state containers, telemetry hooks, and
   assert.ok(html.includes('href="https://app.kriegspiel.org/"'));
   assert.ok(html.includes('>Play</a>'));
   assert.ok(!html.includes('href="/players/a"'));
-  assert.ok(html.includes('(bot)'));
+  assert.ok(html.includes('Top human players by overall rating'));
+  assert.ok(html.includes('Overall rating'));
+  assert.ok(!html.includes('Trend'));
   const navHtml = html.match(/<nav class="site-nav" aria-label="Primary">([\s\S]*?)<\/nav>/)?.[1] || '';
   assert.ok(!navHtml.includes('>Home</a>'));
   assert.ok(!navHtml.includes('>Changelog</a>'));


### PR DESCRIPTION
## Summary
- make kriegspiel.org leaderboard human-only and overall-rating only
- remove the static trend column because it was not backed by real movement data
- bump ks-home to 1.0.22

## Testing
- npm run build
- node --test tests/home-leaderboard-pages.test.mjs
- node scripts/test-smoke-routes.mjs