### PR TITLE
fix: render markdown thematic breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "0.1.0",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "0.1.0",
+      "version": "1.0.23",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/content-utils.mjs
+++ b/src/content-utils.mjs
@@ -155,6 +155,13 @@ export function markdownToHtml(markdown, options = {}) {
       continue;
     }
 
+    if (/^(?:-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
+      flushParagraph();
+      flushList();
+      html.push("<hr />");
+      continue;
+    }
+
     const nextTrimmed = index + 1 < lines.length ? lines[index + 1].trim() : "";
     if (trimmed.includes("|") && isMarkdownTableSeparator(nextTrimmed)) {
       flushParagraph();

--- a/tests/content-utils.test.mjs
+++ b/tests/content-utils.test.mjs
@@ -152,6 +152,20 @@ test("markdownToHtml renders markdown tables", () => {
   assert.ok(html.includes("<td>Minimal random bot</td>"));
 });
 
+test("markdownToHtml renders thematic breaks as horizontal rules", () => {
+  const html = markdownToHtml([
+    "Before",
+    "",
+    "---",
+    "",
+    "After"
+  ].join("\n"));
+
+  assert.ok(html.includes("<p>Before</p>"));
+  assert.ok(html.includes("<hr />"));
+  assert.ok(html.includes("<p>After</p>"));
+});
+
 test("markdownToHtml highlights include-code snippets with the same renderer", () => {
   const fixtureDir = path.join(process.cwd(), "tests", "fixtures", "snippet-highlight");
   const html = markdownToHtml('::include-code src="example.sh"', { baseDir: fixtureDir });


### PR DESCRIPTION
## Summary
- add markdown thematic break support to the static-site renderer
- cover it with a focused content-utils test
- bump ks-home to 1.0.23

## Testing
- node --test tests/content-utils.test.mjs
- PATH=/home/fil/.nvm/versions/node/v20.19.0/bin:$PATH npm run build