### PR TITLE
[codex] Update rules index statuses

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.0.33
+
+- **Rules Index**: marked the implemented online rulesets as live and added
+  placeholders for RAND and CrazyKrieg rules.
+
 ## ks-home v. 1.0.32
 
 - **Rules Comparison**: refined wording for Berkeley, Cincinnati, and Wild 16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -202,28 +202,41 @@ export function renderChangelogIndex(entries, footerEntry = null) {
 export const renderChangelogDetail = (entry, footerEntry = null) => renderShell({ footerEntry, title: `Kriegspiel — ${entry.metadata.title}`, description: entry.metadata.summary, activeNav: '/changelog', canonicalPath: `/changelog/${entry.metadata.slug}`, ogType: 'article', structuredData: { '@context': 'https://schema.org', '@type': 'Article', headline: entry.metadata.title, datePublished: entry.metadata.publishedAt, dateModified: entry.metadata.updatedAt, author: { '@type': 'Organization', name: entry.metadata.author }, mainEntityOfPage: absUrl(`/changelog/${entry.metadata.slug}`) }, main: `<article class="prose-card"><h1>${entry.metadata.title}</h1><p><small>Version ${entry.metadata.version} • ${entry.metadata.publishedAt}</small></p><p>${entry.metadata.summary}</p>${entry.bodyHtml}<p><a class="text-link" href="/changelog">Back to changelog</a></p></article>` });
 
 export function renderRulesPage(entries, changelogEntries, footerEntry = null) {
-  const primary = ['berkeley', 'cincinnati', 'wild16']
-    .map((slug) => entries.find((entry) => entry.metadata.slug === slug))
-    .filter(Boolean);
   const ruleNotes = {
     berkeley: {
-      summary: 'Classic referee-led Kriegspiel with clean announcements, standard hidden-information play, and the optional Any extension available today on the live app.',
-      status: 'Implemented, play today'
+      summary: 'Classic referee-led Kriegspiel with clean announcements, standard hidden-information play, and the Berkeley + Any extension.',
+      status: 'Implemented online'
     },
     cincinnati: {
       summary: 'Historical public rules centered on legal tries, Illegal vs Nonsense, official own pieces, and public pawn-capture notices.',
-      status: 'Reference rules, not implemented online'
+      status: 'Implemented online'
     },
     wild16: {
       summary: 'Different capture announcements and a built-in pawn-tries rule. Read it alongside Berkeley if you want the shared game flow with the Wild 16-specific calls.',
-      status: 'Work in progress, play soon'
+      status: 'Implemented online'
     }
   };
-  const cards = primary.map((entry) => {
+  const primaryCards = ['berkeley', 'cincinnati', 'wild16']
+    .map((slug) => entries.find((entry) => entry.metadata.slug === slug))
+    .filter(Boolean)
+    .map((entry) => {
     const note = ruleNotes[entry.metadata.slug] || { summary: entry.metadata.summary, status: '' };
     return `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Ruleset</p><h2>${prettyRuleLabel(entry.metadata.slug)}</h2><p>${esc(note.summary)}</p><ul class="rules-tile__meta"><li>${esc(note.status)}</li></ul><div class="rules-tile__actions"><a class="button-link button-link--primary" href="/rules/${entry.metadata.slug}">Read ${prettyRuleLabel(entry.metadata.slug)} rules</a></div></article>`;
-  }).join('');
-  return renderShell({ footerEntry, title: 'Kriegspiel — Rules', description: 'Published rulesets and a quick comparison guide.', activeNav: '/rules', canonicalPath: '/rules', structuredData: { '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Kriegspiel Rules', url: absUrl('/rules') }, main: `<section class="content-section"><div class="section-heading"><h1>Rules</h1><p>Choose a published ruleset, then use the comparison page when you need the differences at a glance.</p></div><div class="feature-grid feature-grid--three rules-grid">${cards}</div><aside class="cta-panel rules-comparison-callout"><div><h2>Need the differences first?</h2><p>See the overall comparison before picking a ruleset.</p></div><div class="cta-panel__actions"><a class="button-link button-link--secondary" href="/rules/comparison/">Open rules comparison</a></div></aside></section>` });
+  });
+  const placeholderCards = [
+    {
+      title: 'RAND rules',
+      summary: 'Placeholder for the RAND / Shapley-line rules notes. We will publish this when the source text is ready.',
+      status: 'Placeholder, not implemented yet'
+    },
+    {
+      title: 'CrazyKrieg rules',
+      summary: 'Placeholder for a future crazyhouse-style hidden-information ruleset.',
+      status: 'Placeholder, not implemented yet'
+    }
+  ].map((entry) => `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Planned ruleset</p><h2>${esc(entry.title)}</h2><p>${esc(entry.summary)}</p><ul class="rules-tile__meta"><li>${esc(entry.status)}</li></ul><div class="rules-tile__actions"><span>Rules placeholder</span></div></article>`);
+  const cards = [...primaryCards, ...placeholderCards].join('');
+  return renderShell({ footerEntry, title: 'Kriegspiel — Rules', description: 'Published rulesets and a quick comparison guide.', activeNav: '/rules', canonicalPath: '/rules', structuredData: { '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Kriegspiel Rules', url: absUrl('/rules') }, main: `<section class="content-section"><div class="section-heading"><h1>Rules</h1><p>Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online. RAND and CrazyKrieg are listed as placeholders for future rules work.</p></div><div class="feature-grid feature-grid--three rules-grid">${cards}</div><aside class="cta-panel rules-comparison-callout"><div><h2>Need the differences first?</h2><p>See the overall comparison before picking a ruleset.</p></div><div class="cta-panel__actions"><a class="button-link button-link--secondary" href="/rules/comparison/">Open rules comparison</a></div></aside></section>` });
 }
 
 export function renderRuleDetailPage(entry, changelogEntries, footerEntry = null) {

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { renderRulesPage, renderRuleDetailPage, renderRulesComparisonPage, renderSiteMarkdownPage } from '../src/pages.mjs';
 
-test('rules landing page shows Berkeley, Cincinnati style, and Wild 16 tiles plus comparison link', () => {
+test('rules landing page shows implemented rules and planned placeholders plus comparison link', () => {
   const html = renderRulesPage([
     { metadata: { slug: 'berkeley', title: 'Berkeley', summary: 'Classic referee calls.' }, body: '# Intro\n\n## Section One' },
     { metadata: { slug: 'cincinnati', title: 'Cincinnati style', summary: 'Historical public try-based rules.' }, body: '# Intro\n\n## Section One B' },
@@ -15,10 +15,16 @@ test('rules landing page shows Berkeley, Cincinnati style, and Wild 16 tiles plu
   assert.ok(html.includes('Historical public rules centered on legal tries'));
   assert.ok(html.includes('Wild 16'));
   assert.ok(html.includes('Different capture announcements and a built-in pawn-tries rule.'));
+  assert.ok(html.includes('Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online.'));
+  assert.ok(html.includes('RAND rules'));
+  assert.ok(html.includes('CrazyKrieg rules'));
+  assert.ok(html.includes('Planned ruleset'));
+  assert.ok(html.includes('Rules placeholder'));
   assert.ok(html.includes('/rules/comparison/'));
-  assert.ok(html.includes('Implemented, play today'));
-  assert.ok(html.includes('Reference rules, not implemented online'));
-  assert.ok(html.includes('Work in progress, play soon'));
+  assert.equal((html.match(/Implemented online/g) || []).length, 3);
+  assert.equal((html.match(/Placeholder, not implemented yet/g) || []).length, 2);
+  assert.ok(!html.includes('Reference rules, not implemented online'));
+  assert.ok(!html.includes('Work in progress, play soon'));
   assert.ok(!html.includes('rules-berkeley-r1'));
   assert.ok(!html.includes('Linked changelog'));
 });


### PR DESCRIPTION
## Summary

- Mark the published online rulesets as implemented on `/rules`.
- Explicitly mention Berkeley + Any in the rules intro/status copy.
- Add placeholder tiles for RAND rules and CrazyKrieg rules without linking to non-existent pages.
- Bump `ks-home` to `1.0.33` and add release notes.

## Why

The rules index still described Cincinnati as reference-only and Wild 16 as work-in-progress, but the engine/app/backend now support those rulesets. The page should reflect the current implementation status while reserving space for future RAND and CrazyKrieg rules work.

## Validation

Remote validation on `rpis02-cf` will be run before merge:

- `npm ci`
- `npm test`
- `npm run build`
- route smoke for `/rules`

Deployment notes will be added after merge and refresh.
