### PR TITLE
[codex] Add release note alias

### DIFF
--- a/RELEASE-NOTE.md
+++ b/RELEASE-NOTE.md
@@ -1,0 +1,4 @@
+# Release Note
+
+See [RELEASE-NOTES.md](./RELEASE-NOTES.md) for the ks-home release history.
+


### PR DESCRIPTION
## Summary

- Add `RELEASE-NOTE.md` as a small compatibility pointer to the canonical `RELEASE-NOTES.md` file.

## Why

Some tooling or habits may look for the singular filename. Keeping the full release history in one canonical file avoids duplicated notes drifting out of sync.

## Validation

- Inspected the new file content.
- Docs-only change; no version bump, site rebuild, or service restart needed.
