### PR TITLE
[codex] Add RAND rules page to index

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.0.34
+
+- **Rules Index**: promoted RAND to a linked historical reference and kept
+  CrazyKrieg as a placeholder without adding "rules" to either display name.
+
 ## ks-home v. 1.0.33
 
 - **Rules Index**: marked the implemented online rulesets as live and added

--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -31,6 +31,7 @@
         { "label": "Berkeley", "href": "/rules/berkeley" },
         { "label": "Cincinnati", "href": "/rules/cincinnati" },
         { "label": "Wild 16", "href": "/rules/wild16" },
+        { "label": "RAND", "href": "/rules/rand" },
         { "label": "Comparison", "href": "/rules/comparison/" }
       ]
     },
@@ -70,6 +71,7 @@
     { "label": "Berkeley", "href": "/rules/berkeley" },
     { "label": "Cincinnati", "href": "/rules/cincinnati" },
     { "label": "Wild 16", "href": "/rules/wild16" },
+    { "label": "RAND", "href": "/rules/rand" },
     { "label": "Comparison", "href": "/rules/comparison/" },
     { "label": "Blog", "href": "/blog" },
     { "label": "Changelog", "href": "/changelog" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -31,7 +31,7 @@ function parseFooterEntry(footerEntry) {
 
 function renderFooter(footerEntry) {
   const fallbackGroups = [
-    { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/comparison/', 'Comparison']] },
+    { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/comparison/', 'Comparison']] },
     { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/', 'About']] },
     { title: 'Social', links: [['https://x.com/kriegspiel_org', 'X.com (@kriegspiel_org)'], ['https://github.com/Kriegspiel', 'GitHub']] }
   ];
@@ -59,6 +59,7 @@ function jsonLd(data) { return `<script type="application/ld+json">${JSON.string
 function sectionsFromBody(body = '', limit = 4) { return body.split(/\r?\n\r?\n/).filter(Boolean).filter((block) => /^#/.test(block.trim())).slice(0, limit).map((block) => esc(block.split(/\r?\n/)[0].replace(/^#+\s*/, ''))); }
 function prettyRuleLabel(slug = '') {
   if (slug === 'wild16') return 'Wild 16';
+  if (slug === 'rand') return 'RAND';
   if (slug === 'cincinnati') return 'Cincinnati style';
   return slug.charAt(0).toUpperCase() + slug.slice(1);
 }
@@ -214,29 +215,28 @@ export function renderRulesPage(entries, changelogEntries, footerEntry = null) {
     wild16: {
       summary: 'Different capture announcements and a built-in pawn-tries rule. Read it alongside Berkeley if you want the shared game flow with the Wild 16-specific calls.',
       status: 'Implemented online'
+    },
+    rand: {
+      summary: 'Historical RAND rules from J. D. Williams, including pawn-try squares, typed captures, promotion announcements, and rebuff counts.',
+      status: 'Historical reference'
     }
   };
-  const primaryCards = ['berkeley', 'cincinnati', 'wild16']
+  const primaryCards = ['berkeley', 'cincinnati', 'wild16', 'rand']
     .map((slug) => entries.find((entry) => entry.metadata.slug === slug))
     .filter(Boolean)
     .map((entry) => {
     const note = ruleNotes[entry.metadata.slug] || { summary: entry.metadata.summary, status: '' };
-    return `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Ruleset</p><h2>${prettyRuleLabel(entry.metadata.slug)}</h2><p>${esc(note.summary)}</p><ul class="rules-tile__meta"><li>${esc(note.status)}</li></ul><div class="rules-tile__actions"><a class="button-link button-link--primary" href="/rules/${entry.metadata.slug}">Read ${prettyRuleLabel(entry.metadata.slug)} rules</a></div></article>`;
+    return `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Ruleset</p><h2>${prettyRuleLabel(entry.metadata.slug)}</h2><p>${esc(note.summary)}</p><ul class="rules-tile__meta"><li>${esc(note.status)}</li></ul><div class="rules-tile__actions"><a class="button-link button-link--primary" href="/rules/${entry.metadata.slug}">Read ${prettyRuleLabel(entry.metadata.slug)}</a></div></article>`;
   });
   const placeholderCards = [
     {
-      title: 'RAND rules',
-      summary: 'Placeholder for the RAND / Shapley-line rules notes. We will publish this when the source text is ready.',
-      status: 'Placeholder, not implemented yet'
-    },
-    {
-      title: 'CrazyKrieg rules',
+      title: 'CrazyKrieg',
       summary: 'Placeholder for a future crazyhouse-style hidden-information ruleset.',
       status: 'Placeholder, not implemented yet'
     }
-  ].map((entry) => `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Planned ruleset</p><h2>${esc(entry.title)}</h2><p>${esc(entry.summary)}</p><ul class="rules-tile__meta"><li>${esc(entry.status)}</li></ul><div class="rules-tile__actions"><span>Rules placeholder</span></div></article>`);
+  ].map((entry) => `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Planned ruleset</p><h2>${esc(entry.title)}</h2><p>${esc(entry.summary)}</p><ul class="rules-tile__meta"><li>${esc(entry.status)}</li></ul><div class="rules-tile__actions"><span>Placeholder</span></div></article>`);
   const cards = [...primaryCards, ...placeholderCards].join('');
-  return renderShell({ footerEntry, title: 'Kriegspiel — Rules', description: 'Published rulesets and a quick comparison guide.', activeNav: '/rules', canonicalPath: '/rules', structuredData: { '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Kriegspiel Rules', url: absUrl('/rules') }, main: `<section class="content-section"><div class="section-heading"><h1>Rules</h1><p>Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online. RAND and CrazyKrieg are listed as placeholders for future rules work.</p></div><div class="feature-grid feature-grid--three rules-grid">${cards}</div><aside class="cta-panel rules-comparison-callout"><div><h2>Need the differences first?</h2><p>See the overall comparison before picking a ruleset.</p></div><div class="cta-panel__actions"><a class="button-link button-link--secondary" href="/rules/comparison/">Open rules comparison</a></div></aside></section>` });
+  return renderShell({ footerEntry, title: 'Kriegspiel — Rules', description: 'Published rulesets and a quick comparison guide.', activeNav: '/rules', canonicalPath: '/rules', structuredData: { '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Kriegspiel Rules', url: absUrl('/rules') }, main: `<section class="content-section"><div class="section-heading"><h1>Rules</h1><p>Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online. RAND is published as a historical reference, and CrazyKrieg is a placeholder for future rules work.</p></div><div class="feature-grid feature-grid--three rules-grid">${cards}</div><aside class="cta-panel rules-comparison-callout"><div><h2>Need the differences first?</h2><p>See the overall comparison before picking a ruleset.</p></div><div class="cta-panel__actions"><a class="button-link button-link--secondary" href="/rules/comparison/">Open rules comparison</a></div></aside></section>` });
 }
 
 export function renderRuleDetailPage(entry, changelogEntries, footerEntry = null) {

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -217,7 +217,7 @@ export function renderRulesPage(entries, changelogEntries, footerEntry = null) {
       status: 'Implemented online'
     },
     rand: {
-      summary: 'Historical RAND rules from J. D. Williams, including pawn-try squares, typed captures, promotion announcements, and rebuff counts.',
+      summary: 'Historical RAND reference from J. D. Williams, including pawn-try squares, typed captures, promotion announcements, and rebuff counts.',
       status: 'Historical reference'
     }
   };

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -6,7 +6,7 @@ import { execSync } from 'node:child_process';
 
 test('build emits required public pages', () => {
   execSync('node scripts/build.mjs', { stdio: 'pipe' });
-  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/comparison/index.html', 'privacy/index.html', 'terms/index.html']) {
+  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/comparison/index.html', 'privacy/index.html', 'terms/index.html']) {
     assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', routeFile)), `missing ${routeFile}`);
   }
 });

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -20,7 +20,7 @@ test('rules landing page shows implemented rules and planned placeholders plus c
   assert.ok(html.includes('Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online.'));
   assert.ok(html.includes('RAND is published as a historical reference'));
   assert.ok(html.includes('RAND'));
-  assert.ok(html.includes('Historical RAND rules from J. D. Williams'));
+  assert.ok(html.includes('Historical RAND reference from J. D. Williams'));
   assert.ok(html.includes('CrazyKrieg'));
   assert.ok(html.includes('Planned ruleset'));
   assert.ok(html.includes('Placeholder'));

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -6,23 +6,30 @@ test('rules landing page shows implemented rules and planned placeholders plus c
   const html = renderRulesPage([
     { metadata: { slug: 'berkeley', title: 'Berkeley', summary: 'Classic referee calls.' }, body: '# Intro\n\n## Section One' },
     { metadata: { slug: 'cincinnati', title: 'Cincinnati style', summary: 'Historical public try-based rules.' }, body: '# Intro\n\n## Section One B' },
-    { metadata: { slug: 'wild16', title: 'Wild 16', summary: 'ICC-style announcements.' }, body: '# Intro\n\n## Section Two' }
+    { metadata: { slug: 'wild16', title: 'Wild 16', summary: 'ICC-style announcements.' }, body: '# Intro\n\n## Section Two' },
+    { metadata: { slug: 'rand', title: 'RAND', summary: 'RAND reference.' }, body: '# Intro\n\n## Section Three' }
   ], []);
   assert.ok(html.includes('/rules/berkeley'));
   assert.ok(html.includes('/rules/cincinnati'));
   assert.ok(html.includes('/rules/wild16'));
+  assert.ok(html.includes('/rules/rand'));
   assert.ok(html.includes('Cincinnati'));
   assert.ok(html.includes('Historical public rules centered on legal tries'));
   assert.ok(html.includes('Wild 16'));
   assert.ok(html.includes('Different capture announcements and a built-in pawn-tries rule.'));
   assert.ok(html.includes('Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online.'));
-  assert.ok(html.includes('RAND rules'));
-  assert.ok(html.includes('CrazyKrieg rules'));
+  assert.ok(html.includes('RAND is published as a historical reference'));
+  assert.ok(html.includes('RAND'));
+  assert.ok(html.includes('Historical RAND rules from J. D. Williams'));
+  assert.ok(html.includes('CrazyKrieg'));
   assert.ok(html.includes('Planned ruleset'));
-  assert.ok(html.includes('Rules placeholder'));
+  assert.ok(html.includes('Placeholder'));
   assert.ok(html.includes('/rules/comparison/'));
   assert.equal((html.match(/Implemented online/g) || []).length, 3);
-  assert.equal((html.match(/Placeholder, not implemented yet/g) || []).length, 2);
+  assert.equal((html.match(/Historical reference/g) || []).length, 1);
+  assert.equal((html.match(/Placeholder, not implemented yet/g) || []).length, 1);
+  assert.ok(!html.includes('RAND rules'));
+  assert.ok(!html.includes('CrazyKrieg rules'));
   assert.ok(!html.includes('Reference rules, not implemented online'));
   assert.ok(!html.includes('Work in progress, play soon'));
   assert.ok(!html.includes('rules-berkeley-r1'));


### PR DESCRIPTION
## Summary

- Promote RAND from a placeholder to a linked historical reference on `/rules`.
- Keep CrazyKrieg as the only planned placeholder, titled exactly `CrazyKrieg`.
- Stop adding the word `rules` to the RAND and CrazyKrieg display names.
- Add RAND to fallback/navigation contracts and route build smoke expectations.
- Bump `ks-home` to `1.0.34` and add release notes.

## Why

The paired content PR adds the RAND source text as `/rules/rand`. The static site needs to surface that page and keep the rules index copy aligned with the new status.

## Paired PR

- Content: https://github.com/Kriegspiel/content/pull/79

## Validation

Remote validation on `rpis02-cf` will be run against this branch plus the paired content branch before merge.
