### PR TITLE
Mark all published rulesets as implemented

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.0.45
+
+- **Rules Index**: marked RAND, English, and CrazyKrieg as implemented online
+  alongside Berkeley, Cincinnati, and Wild 16.
+
 ## ks-home v. 1.0.44
 
 - **Rules Comparison**: simplified matching illegal-try and promotion wording

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -219,15 +219,15 @@ export function renderRulesPage(entries, changelogEntries, footerEntry = null) {
     },
     rand: {
       summary: 'Historical RAND reference from J. D. Williams, including pawn-try squares, typed captures, promotion announcements, and rebuff counts.',
-      status: 'Historical reference'
+      status: 'Implemented online'
     },
     english: {
       summary: 'Gambit Club English rules with three boards, umpire-controlled legality, capture-square announcements, directional checks, and the classic Any? question.',
-      status: 'Historical reference'
+      status: 'Implemented online'
     },
     crazykrieg: {
       summary: 'Crazyhouse mixed with Kriegspiel: hidden board, public reserves, typed captures, and secret drop squares.',
-      status: 'Reference rules'
+      status: 'Implemented online'
     }
   };
   const cards = ['berkeley', 'cincinnati', 'wild16', 'rand', 'english', 'crazykrieg']
@@ -237,7 +237,7 @@ export function renderRulesPage(entries, changelogEntries, footerEntry = null) {
     const note = ruleNotes[entry.metadata.slug] || { summary: entry.metadata.summary, status: '' };
     return `<article class="surface-card rules-tile"><p class="rules-tile__eyebrow">Ruleset</p><h2>${prettyRuleLabel(entry.metadata.slug)}</h2><p>${esc(note.summary)}</p><ul class="rules-tile__meta"><li>${esc(note.status)}</li></ul><div class="rules-tile__actions"><a class="button-link button-link--primary" href="/rules/${entry.metadata.slug}">Read ${prettyRuleLabel(entry.metadata.slug)}</a></div></article>`;
   }).join('');
-  return renderShell({ footerEntry, title: 'Kriegspiel — Rules', description: 'Published rulesets and a quick comparison guide.', activeNav: '/rules', canonicalPath: '/rules', structuredData: { '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Kriegspiel Rules', url: absUrl('/rules') }, main: `<section class="content-section"><div class="section-heading"><h1>Rules</h1><p>Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online. RAND, English, and CrazyKrieg are published as reference rulesets.</p></div><div class="feature-grid feature-grid--three rules-grid">${cards}</div><aside class="cta-panel rules-comparison-callout"><div><h2>Need the differences first?</h2><p>See the overall comparison before picking a ruleset.</p></div><div class="cta-panel__actions"><a class="button-link button-link--secondary" href="/rules/comparison/">Open rules comparison</a></div></aside></section>` });
+  return renderShell({ footerEntry, title: 'Kriegspiel — Rules', description: 'Published rulesets and a quick comparison guide.', activeNav: '/rules', canonicalPath: '/rules', structuredData: { '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Kriegspiel Rules', url: absUrl('/rules') }, main: `<section class="content-section"><div class="section-heading"><h1>Rules</h1><p>All published rulesets are implemented online: Berkeley, Berkeley + Any, Cincinnati, Wild 16, RAND, English, and CrazyKrieg.</p></div><div class="feature-grid feature-grid--three rules-grid">${cards}</div><aside class="cta-panel rules-comparison-callout"><div><h2>Need the differences first?</h2><p>See the overall comparison before picking a ruleset.</p></div><div class="cta-panel__actions"><a class="button-link button-link--secondary" href="/rules/comparison/">Open rules comparison</a></div></aside></section>` });
 }
 
 export function renderRuleDetailPage(entry, changelogEntries, footerEntry = null) {

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -22,8 +22,7 @@ test('rules landing page shows implemented and reference rules plus comparison l
   assert.ok(html.includes('Historical public rules centered on legal tries'));
   assert.ok(html.includes('Wild 16'));
   assert.ok(html.includes('Different capture announcements and a built-in pawn-tries rule.'));
-  assert.ok(html.includes('Berkeley, Berkeley + Any, Cincinnati, and Wild 16 are implemented online.'));
-  assert.ok(html.includes('RAND, English, and CrazyKrieg are published as reference rulesets.'));
+  assert.ok(html.includes('All published rulesets are implemented online: Berkeley, Berkeley + Any, Cincinnati, Wild 16, RAND, English, and CrazyKrieg.'));
   assert.ok(html.includes('RAND'));
   assert.ok(html.includes('Historical RAND reference from J. D. Williams'));
   assert.ok(html.includes('English'));
@@ -31,9 +30,7 @@ test('rules landing page shows implemented and reference rules plus comparison l
   assert.ok(html.includes('CrazyKrieg'));
   assert.ok(html.includes('Crazyhouse mixed with Kriegspiel'));
   assert.ok(html.includes('/rules/comparison/'));
-  assert.equal((html.match(/Implemented online/g) || []).length, 3);
-  assert.equal((html.match(/Historical reference/g) || []).length, 2);
-  assert.equal((html.match(/Reference rules/g) || []).length, 1);
+  assert.equal((html.match(/Implemented online/g) || []).length, 6);
   assert.ok(!html.includes('RAND rules'));
   assert.ok(!html.includes('Planned ruleset'));
   assert.ok(!html.includes('Placeholder'));


### PR DESCRIPTION
## What changed

- Marked RAND, English, and CrazyKrieg as implemented online on the rules landing page.
- Updated the landing-page summary so all published rulesets are listed as implemented.
- Bumped `ks-home` to `1.0.45`.

## Why

The game stack now supports every published ruleset, so the public rules page should no longer describe RAND, English, or CrazyKrieg as reference-only.

## Local validation

- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-current-all-rulesets npm test` -> `36 passed`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-current-all-rulesets npm run build` -> passed

## Deployment notes

- Static-site code changed; deploy requires fast-forwarding `ks-home`, building with current `content`, and triggering `ks-home-refresh.service` or equivalent refresh.
