### PR TITLE
Publish social card asset in static build

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,12 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.0.47
+
+- **Social Card Asset**: copied the social preview PNG into generated static
+  output and extended SEO validation to fail if an OpenGraph image is missing
+  from `dist/`.
+
 ## ks-home v. 1.0.46
 
 - **Social Link Cards**: added a versioned OpenGraph/Twitter preview image and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -54,6 +54,7 @@ const apiBase = process.env.KS_API_BASE ? process.env.KS_API_BASE.replace(/\/$/,
 fs.rmSync(dist, { recursive: true, force: true });
 fs.mkdirSync(dist, { recursive: true });
 copyStaticAsset('static/logo-theme-toggle.png', 'logo-theme-toggle.png');
+copyStaticAsset('static/social-card-20260511.png', 'social-card-20260511.png');
 copyContentAsset('binary/logo/favicon.ico', 'favicon.ico');
 copyContentAsset('binary/logo/favicon-16x16.png', 'favicon-16x16.png');
 copyContentAsset('binary/logo/favicon-32x32.png', 'favicon-32x32.png');

--- a/scripts/seo-validate.mjs
+++ b/scripts/seo-validate.mjs
@@ -32,6 +32,14 @@ for (const route of routes) {
       failures += 1;
     }
   }
+  const imageMatch = html.match(/<meta\s+property="og:image"\s+content="https:\/\/kriegspiel\.org\/([^"#?]+)(?:[?#][^"]*)?"\s*\/>/i);
+  if (imageMatch) {
+    const imagePath = path.join(process.cwd(), "dist", imageMatch[1]);
+    if (!fs.existsSync(imagePath)) {
+      console.error(`${route}: referenced social image is missing from dist: ${imageMatch[1]}`);
+      failures += 1;
+    }
+  }
 }
 
 if (failures > 0) process.exit(1);

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -9,4 +9,5 @@ test('build emits required public pages', () => {
   for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'privacy/index.html', 'terms/index.html']) {
     assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', routeFile)), `missing ${routeFile}`);
   }
+  assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', 'social-card-20260511.png')), 'missing social-card-20260511.png');
 });


### PR DESCRIPTION
## Summary
- Copy `social-card-20260511.png` into the generated `dist/` output.
- Extend the build smoke test to assert the social-card PNG is emitted.
- Extend SEO validation to fail when the `og:image` target is missing from `dist/`.
- Bump ks-home to v. 1.0.47 and update release notes.

## Local validation
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-social-link-cards npm test`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-social-link-cards npm run build`
- `npm run seo:validate`
- `npm run lint`
- verified `dist/social-card-20260511.png` is a 1200x630 PNG

## Deployment notes
- Refresh `ks-home` after merge so the PNG is copied into the served static snapshot.