### PR TITLE
Use prefix-free API paths for static data

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,12 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.0.49
+
+- **API Contract**: static leaderboard regeneration now uses prefix-free
+  `api.kriegspiel.org` paths so the public API host can reject `/api/...`
+  while the browser app keeps same-origin `/api` traffic.
+
 ## ks-home v. 1.0.48
 
 - **Prose Tables**: let long inline-code values wrap inside markdown tables so

--- a/contracts/leaderboard-contract.json
+++ b/contracts/leaderboard-contract.json
@@ -1,5 +1,5 @@
 {
-  "endpoint": "/api/leaderboard",
+  "endpoint": "/leaderboard",
   "cachePolicy": {
     "request": "no-store",
     "staleThresholdMs": 900000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -121,8 +121,8 @@ async function loadPublicPlayerData() {
     const username = String(entry.username || '').trim();
     if (!username) continue;
     const [profile, history] = await Promise.all([
-      fetchJson(`${apiBase}/api/user/${encodeURIComponent(username)}`),
-      fetchJson(`${apiBase}/api/user/${encodeURIComponent(username)}/games?page=1&per_page=20`),
+      fetchJson(`${apiBase}/user/${encodeURIComponent(username)}`),
+      fetchJson(`${apiBase}/user/${encodeURIComponent(username)}/games?page=1&per_page=20`),
     ]);
     profiles.push({
       profile,
@@ -134,11 +134,11 @@ async function loadPublicPlayerData() {
 
 async function loadLeaderboardEntriesFromApi() {
   const perPage = 20;
-  const firstPage = await fetchJson(`${apiBase}/api/leaderboard?page=1&per_page=${perPage}`);
+  const firstPage = await fetchJson(`${apiBase}/leaderboard?page=1&per_page=${perPage}`);
   const pages = Number(firstPage?.pagination?.pages || 1);
   const players = Array.isArray(firstPage?.players) ? [...firstPage.players] : [];
   for (let page = 2; page <= pages; page += 1) {
-    const payload = await fetchJson(`${apiBase}/api/leaderboard?page=${page}&per_page=${perPage}`);
+    const payload = await fetchJson(`${apiBase}/leaderboard?page=${page}&per_page=${perPage}`);
     if (Array.isArray(payload?.players)) players.push(...payload.players);
   }
   return players.map((player) => ({

--- a/tests/content-utils.test.mjs
+++ b/tests/content-utils.test.mjs
@@ -119,7 +119,7 @@ test("markdownToHtml renders fenced code blocks and ordered lists", () => {
     "2. Save the returned token",
     "",
     "```bash",
-    "curl -X POST https://api.kriegspiel.org/api/auth/bots/register \\",
+    "curl -X POST https://api.kriegspiel.org/auth/bots/register \\",
     "  -H \"Content-Type: application/json\"",
     "```"
   ].join("\n"));
@@ -127,7 +127,7 @@ test("markdownToHtml renders fenced code blocks and ordered lists", () => {
   assert.ok(html.includes("<ol><li>Register the bot</li><li>Save the returned token</li></ol>"));
   assert.ok(html.includes('<pre><code class="hljs language-bash">'));
   assert.match(html, /<span class="hljs-string">&quot;Content-Type: application\/json&quot;<\/span>|Content-Type: application\/json/);
-  assert.ok(html.includes("https://api.kriegspiel.org/api/auth/bots/register"));
+  assert.ok(html.includes("https://api.kriegspiel.org/auth/bots/register"));
 });
 
 test("markdownToHtml keeps spaced and nested ordered lists in one hierarchy", () => {

--- a/tests/leaderboard-contract.test.mjs
+++ b/tests/leaderboard-contract.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 const contract = JSON.parse(fs.readFileSync(new URL("../contracts/leaderboard-contract.json", import.meta.url), "utf8"));
 
 test("leaderboard contract documents endpoint and required fields", () => {
-  assert.equal(contract.endpoint, "/api/leaderboard");
+  assert.equal(contract.endpoint, "/leaderboard");
   assert.ok(contract.requiredTopLevelFields.includes("players"));
   assert.equal(contract.cachePolicy.request, "no-store");
 });


### PR DESCRIPTION
## Summary
- switches static leaderboard/profile regeneration to prefix-free `api.kriegspiel.org` paths
- updates the leaderboard contract and tests to document `/leaderboard`
- bumps ks-home to 1.0.49

## Validation
- `git diff --check`
- remote validation pending before merge

## Deployment
- refresh static site after merge
- verify `https://kriegspiel.org/leaderboard` renders from the regenerated snapshot