### PR TITLE
[codex] Bump website version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.0.50",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.0.50",
+      "version": "1.1.0",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.0.50",
+  "version": "1.1.0",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `ks-home` from 1.0.50 to 1.1.0 to mark the FEN diagram renderer as a website feature release.
- Keep `package-lock.json` root package metadata in sync.

## Validation

- `npm run lint`
- `env KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-invisible-chessboard-problems npm run build`
- `env KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-invisible-chessboard-problems npm run test:smoke -- --routes=/blog/la-scacchiera-invisibile-problems`
- `git diff --check`

Note: the first build/smoke attempt in the fresh worktree failed before validation because `node_modules` was not installed; `npm ci` completed successfully and the checks above passed afterward.