### PR TITLE
[codex] Improve problem board phantom removal behavior

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,12 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.6
+
+- **Problem Boards**: prevented phantom pieces from being placed on occupied
+  squares and made dragged-off-board pieces disappear for both real and phantom
+  pieces.
+
 ## ks-home v. 1.2.5
 
 - **Problem Boards**: fixed static FEN board row sizing so all eight ranks share

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/static/fen-board.js
+++ b/static/fen-board.js
@@ -65,9 +65,7 @@
     diagram.addEventListener("dragover", handleDragOver);
     diagram.addEventListener("dragleave", handleDragLeave);
     diagram.addEventListener("drop", handleDrop);
-    diagram.addEventListener("dragend", function () {
-      clearDragTargets(diagram);
-    });
+    diagram.addEventListener("dragend", handleDragEnd);
   }
 
   function handleDocumentClick(event) {
@@ -114,6 +112,11 @@
       return;
     }
 
+    if (!canPlacePhantom(square)) {
+      closeActiveMenu();
+      return;
+    }
+
     openPhantomMenu(diagram, square, event);
   }
 
@@ -130,6 +133,7 @@
     if (!payload.square) return;
 
     selectSquare(diagram, square, payload.kind);
+    diagram.dataset.fenDropHandled = "false";
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("application/x-ks-fen-piece", JSON.stringify(payload));
     event.dataTransfer.setData("text/plain", payload.kind + ":" + payload.square);
@@ -155,11 +159,26 @@
     var square = event.target.closest("[data-fen-square]");
     if (!square || !diagram.contains(square)) return;
     event.preventDefault();
+    diagram.dataset.fenDropHandled = "true";
     clearDragTargets(diagram);
 
     var payload = readDragPayload(event);
     if (!payload.square || !payload.kind) return;
     movePiece(diagram, payload.square, square.dataset.square, payload.kind);
+  }
+
+  function handleDragEnd(event) {
+    var diagram = event.currentTarget;
+    var dropHandled = diagram.dataset.fenDropHandled === "true";
+    delete diagram.dataset.fenDropHandled;
+    clearDragTargets(diagram);
+
+    if (dropHandled) return;
+    if (isDropOutsideBoard(diagram, event)) {
+      removeSelectedPiece(diagram);
+      return;
+    }
+    clearSelection(diagram);
   }
 
   function readDragPayload(event) {
@@ -189,9 +208,14 @@
       clearSelection(diagram);
       return;
     }
+    if (kind === "phantom" && !canPlacePhantom(toSquare)) {
+      clearSelection(diagram);
+      return;
+    }
 
     fromSquare.dataset[dataKey] = "";
     toSquare.dataset[dataKey] = piece;
+    if (kind !== "phantom") toSquare.dataset.phantomPiece = "";
     renderSquare(fromSquare);
     renderSquare(toSquare);
     markLastMove(diagram, fromSquare, toSquare);
@@ -202,6 +226,14 @@
     var dataKey = kind === "phantom" ? "phantomPiece" : "piece";
     square.dataset[dataKey] = "";
     renderSquare(square);
+  }
+
+  function removeSelectedPiece(diagram) {
+    var selectedSquareName = diagram.dataset.fenSelectedSquare || "";
+    var selectedKind = diagram.dataset.fenSelectedKind || "";
+    var square = findSquare(diagram, selectedSquareName);
+    if (square && selectedKind) removePiece(square, selectedKind);
+    clearSelection(diagram);
   }
 
   function resetDiagram(diagram) {
@@ -243,7 +275,7 @@
 
       var square = findSquare(diagram, menu.dataset.fenTargetSquare || "");
       var piece = button.dataset.fenPhantomChoice || "";
-      if (square && PIECE_ASSETS[piece]) {
+      if (square && canPlacePhantom(square) && PIECE_ASSETS[piece]) {
         square.dataset.phantomPiece = piece;
         renderSquare(square);
       }
@@ -255,6 +287,7 @@
   }
 
   function openPhantomMenu(diagram, square, event) {
+    if (!canPlacePhantom(square)) return;
     closeActiveMenu();
     var menu = diagram.querySelector("[data-fen-phantom-menu]");
     if (!menu) menu = createPhantomMenu(diagram);
@@ -328,6 +361,13 @@
     });
   }
 
+  function isDropOutsideBoard(diagram, event) {
+    if (event.clientX === 0 && event.clientY === 0) return false;
+    var grid = diagram.querySelector("[data-fen-grid]");
+    var target = document.elementFromPoint(event.clientX, event.clientY);
+    return !!grid && (!target || !grid.contains(target));
+  }
+
   function closeActiveMenu() {
     if (!activeMenu) return;
     activeMenu.hidden = true;
@@ -348,6 +388,8 @@
       piece.remove();
     });
 
+    if (square.dataset.piece) square.dataset.phantomPiece = "";
+
     if (square.dataset.phantomPiece) {
       square.appendChild(createPiece(square.dataset.phantomPiece, "phantom"));
       square.dataset.fenPhantom = "true";
@@ -359,6 +401,10 @@
 
     if (square.dataset.piece) square.appendChild(createPiece(square.dataset.piece, "piece"));
     square.setAttribute("aria-label", squareLabel(square));
+  }
+
+  function canPlacePhantom(square) {
+    return !square.dataset.piece;
   }
 
   function createPiece(piece, kind) {

--- a/tests/fen-board-script.test.mjs
+++ b/tests/fen-board-script.test.mjs
@@ -24,3 +24,24 @@ test("FEN board script renders pieces with live-board class aliases", () => {
   assert.ok(script.includes('"fen-board__piece-image phantom-piece-on-board__image"'));
   assert.ok(script.includes('"fen-board__piece-image piece__image"'));
 });
+
+test("FEN board script keeps phantoms off occupied squares", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("function canPlacePhantom(square)"));
+  assert.ok(script.includes('if (!canPlacePhantom(square)) {'));
+  assert.ok(script.includes('if (kind === "phantom" && !canPlacePhantom(toSquare))'));
+  assert.ok(script.includes("square && canPlacePhantom(square) && PIECE_ASSETS[piece]"));
+  assert.ok(script.includes("if (square.dataset.piece) square.dataset.phantomPiece = \"\";"));
+});
+
+test("FEN board script removes dragged-off-board pieces", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes('diagram.addEventListener("dragend", handleDragEnd)'));
+  assert.ok(script.includes('diagram.dataset.fenDropHandled = "false"'));
+  assert.ok(script.includes('diagram.dataset.fenDropHandled = "true"'));
+  assert.ok(script.includes("function removeSelectedPiece(diagram)"));
+  assert.ok(script.includes("removeSelectedPiece(diagram);"));
+  assert.ok(script.includes("document.elementFromPoint(event.clientX, event.clientY)"));
+});

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -21,7 +21,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="canonical" href="https://kriegspiel.org/" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.5" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.6" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes("grid-template-columns:repeat(8,minmax(0,1fr));grid-template-rows:repeat(8,minmax(0,1fr));"));


### PR DESCRIPTION
## Summary
- Prevent static FEN/problem boards from adding phantom pieces on squares that already contain real pieces.
- Re-check the same invariant from the phantom menu click path and when dragging a phantom onto another square.
- Remove impossible `piece + phantom` square state during rendering, and clear a phantom when a real piece moves onto its square.
- Let dragged-off-board real pieces and phantom pieces disappear, matching the board-editing expectation.
- Bump `ks-home` to `1.2.6` and document the behavior change.

## Validation
- `node scripts/lint.mjs`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node --test tests/*.mjs`
- `PATH=node_modules/.bin:$PATH KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/run-tests.mjs`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/build.mjs`

Coverage from local run: 96.14% lines, 92.22% branches, 94.44% functions.

## Deployment notes
- Static-site behavior change only.
- After merge, refresh/restart `ks-home` and verify the problems page serves `fen-board.js?v=1.2.6`.
