### PR TITLE
[codex] Deselect problem board pieces on same-square click

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.8
+
+- **Problem Boards**: changed same-square clicks to deselect the selected piece
+  instead of removing it, while preserving dragged-off-board removal.
+
 ## ks-home v. 1.2.7
 
 - **Problem Boards**: aligned interactive square highlighting with the main app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/static/fen-board.js
+++ b/static/fen-board.js
@@ -86,7 +86,6 @@
     var selectedKind = diagram.dataset.fenSelectedKind || "";
     if (selectedSquareName && selectedKind) {
       if (selectedSquareName === square.dataset.square) {
-        removePiece(square, selectedKind);
         clearSelection(diagram);
       } else {
         movePiece(diagram, selectedSquareName, square.dataset.square, selectedKind);

--- a/tests/fen-board-script.test.mjs
+++ b/tests/fen-board-script.test.mjs
@@ -45,3 +45,10 @@ test("FEN board script removes dragged-off-board pieces", () => {
   assert.ok(script.includes("removeSelectedPiece(diagram);"));
   assert.ok(script.includes("document.elementFromPoint(event.clientX, event.clientY)"));
 });
+
+test("FEN board script deselects instead of removing on same-square clicks", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("if (selectedSquareName === square.dataset.square) {\n        clearSelection(diagram);\n      } else {"));
+  assert.ok(!script.includes("if (selectedSquareName === square.dataset.square) {\n        removePiece(square, selectedKind);"));
+});

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -21,7 +21,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="canonical" href="https://kriegspiel.org/" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.7" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.8" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes("grid-template-columns:repeat(8,minmax(0,1fr));grid-template-rows:repeat(8,minmax(0,1fr));"));


### PR DESCRIPTION
## Summary
- Change interactive FEN/problem boards so clicking the selected square again deselects the piece instead of removing it.
- Preserve dragged-off-board removal for real pieces and phantoms.
- Bump ks-home to 1.2.8 and add a regression test for the same-square behavior.

## Local validation
- `node scripts/lint.mjs`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node --test tests/*.mjs`
- `PATH=node_modules/.bin:$PATH KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/run-tests.mjs`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/build.mjs`

## Coverage
- Lines: 96.14%
- Branches: 92.22%
- Functions: 94.44%

## Deployment notes
- Static site runtime change; deploy by rebuilding ks-home and restarting/refreshing ks-home service.
