### PR TITLE
[codex] Format singular blog reading time

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.11
+
+- **Blog**: made reading-time labels grammatically singular for one-minute
+  posts (`1 min read`) and plural otherwise (`N mins read`).
+
 ## ks-home v. 1.2.10
 
 - **Blog**: changed reading-time labels from `min read` to `mins read` across

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -197,11 +197,16 @@ export function renderPublicProfilePage({ profile, games = [], footerEntry = nul
 }
 
 export function renderBlogIndex(entries, footerEntry = null) {
-  const items = entries.map((entry) => `<li class="surface-card"><a href="/blog/${entry.metadata.slug}">${entry.metadata.title}</a> <small>${entry.metadata.publishedAt} • ${readingTimeMinutes(entry.body)} mins read</small><p>${entry.metadata.summary}</p></li>`).join('');
+  const items = entries.map((entry) => `<li class="surface-card"><a href="/blog/${entry.metadata.slug}">${entry.metadata.title}</a> <small>${entry.metadata.publishedAt} • ${readingTimeLabel(entry.body)}</small><p>${entry.metadata.summary}</p></li>`).join('');
   return renderShell({ footerEntry, title: 'Kriegspiel — Blog', description: 'Notes and updates about Kriegspiel.', activeNav: '/blog', canonicalPath: '/blog', main: `<section class="content-section"><div class="section-heading"><h1>Blog</h1><p>Notes and updates about Kriegspiel.</p></div><ul class="stack-list">${items}</ul><p><a class="text-link" href="/blog/archive">Browse archive</a></p></section>` });
 }
 
-export const renderBlogDetail = (entry, footerEntry = null) => renderShell({ footerEntry, title: `Kriegspiel — ${entry.metadata.title}`, description: entry.metadata.summary, activeNav: '/blog', canonicalPath: `/blog/${entry.metadata.slug}`, ogType: 'article', structuredData: { '@context': 'https://schema.org', '@type': 'Article', headline: entry.metadata.title, datePublished: entry.metadata.publishedAt, dateModified: entry.metadata.updatedAt, mainEntityOfPage: absUrl(`/blog/${entry.metadata.slug}`) }, main: `<article class="prose-card"><h1>${entry.metadata.title}</h1><p><small>${entry.metadata.publishedAt} • ${readingTimeMinutes(entry.body)} mins read</small></p><div class="article-summary"><p>${entry.metadata.summary}</p></div>${entry.bodyHtml}<p><a class="text-link" href="/blog">Back to blog</a></p></article>` });
+export const renderBlogDetail = (entry, footerEntry = null) => renderShell({ footerEntry, title: `Kriegspiel — ${entry.metadata.title}`, description: entry.metadata.summary, activeNav: '/blog', canonicalPath: `/blog/${entry.metadata.slug}`, ogType: 'article', structuredData: { '@context': 'https://schema.org', '@type': 'Article', headline: entry.metadata.title, datePublished: entry.metadata.publishedAt, dateModified: entry.metadata.updatedAt, mainEntityOfPage: absUrl(`/blog/${entry.metadata.slug}`) }, main: `<article class="prose-card"><h1>${entry.metadata.title}</h1><p><small>${entry.metadata.publishedAt} • ${readingTimeLabel(entry.body)}</small></p><div class="article-summary"><p>${entry.metadata.summary}</p></div>${entry.bodyHtml}<p><a class="text-link" href="/blog">Back to blog</a></p></article>` });
+
+function readingTimeLabel(text) {
+  const minutes = readingTimeMinutes(text);
+  return `${minutes} ${minutes === 1 ? 'min' : 'mins'} read`;
+}
 
 export function renderBlogArchive(entries, footerEntry = null) {
   const groups = new Map();

--- a/tests/home-leaderboard-pages.test.mjs
+++ b/tests/home-leaderboard-pages.test.mjs
@@ -162,7 +162,7 @@ test("public profile page renders stats and elo history", () => {
   assert.ok(html.includes("Back to leaderboard"));
 });
 
-test("blog pages show date and reading time without the visible author label", () => {
+test("blog pages show date and singular reading time without the visible author label", () => {
   const entry = {
     metadata: {
       slug: "welcome",
@@ -179,15 +179,37 @@ test("blog pages show date and reading time without the visible author label", (
   const indexHtml = renderBlogIndex([entry]);
   assert.ok(indexHtml.includes("Notes and updates about Kriegspiel."));
   assert.ok(indexHtml.includes("2026-03-27"));
-  assert.ok(indexHtml.includes("mins read"));
-  assert.ok(!indexHtml.includes("min read"));
+  assert.ok(indexHtml.includes("1 min read"));
+  assert.ok(!indexHtml.includes("1 mins read"));
   assert.ok(!indexHtml.includes("2026-03-27 • Kriegspiel Team •"));
   assert.ok(!indexHtml.includes("Kriegspiel Team"));
 
   const detailHtml = renderBlogDetail(entry);
   assert.ok(detailHtml.includes("2026-03-27"));
-  assert.ok(detailHtml.includes("mins read"));
-  assert.ok(!detailHtml.includes("min read"));
+  assert.ok(detailHtml.includes("1 min read"));
+  assert.ok(!detailHtml.includes("1 mins read"));
   assert.ok(!detailHtml.includes("2026-03-27 • Kriegspiel Team •"));
   assert.ok(!detailHtml.includes("Kriegspiel Team"));
+});
+
+test("blog pages show plural reading time for longer posts", () => {
+  const entry = {
+    metadata: {
+      slug: "long-note",
+      title: "Long note",
+      summary: "A longer note.",
+      publishedAt: "2026-04-01",
+      updatedAt: "2026-04-01",
+    },
+    body: Array.from({ length: 221 }, (_, index) => `word${index}`).join(" "),
+    bodyHtml: "<p>A longer note.</p>"
+  };
+
+  const indexHtml = renderBlogIndex([entry]);
+  assert.ok(indexHtml.includes("2 mins read"));
+  assert.ok(!indexHtml.includes("2 min read"));
+
+  const detailHtml = renderBlogDetail(entry);
+  assert.ok(detailHtml.includes("2 mins read"));
+  assert.ok(!detailHtml.includes("2 min read"));
 });

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -21,7 +21,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="canonical" href="https://kriegspiel.org/" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.10" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.11" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes(".fen-board{width:22rem;max-width:100%;}"));


### PR DESCRIPTION
## Summary
- Format one-minute blog posts as `1 min read` while keeping plural posts as `N mins read`.
- Add a shared reading-time label helper used by blog index and detail pages.
- Add tests for both singular and plural labels and bump ks-home to v1.2.11.

## Validation
- `node scripts/lint.mjs`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node --test tests/*.mjs` (45 passing)
- `PATH=node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/fil/.codex/tmp/arg0/codex-arg0fR8D3t:/Applications/Codex.app/Contents/Resources KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/run-tests.mjs` (lines 96.15%, branches 92.27%, functions 94.50%)
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/build.mjs`
- Checked generated output for `1 min read`, `30 mins read`, and no standalone `1 mins read`.