### PR TITLE
[codex] Lazy initialize problem boards

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,12 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.12
+
+- **Problem Boards**: lazy-initialize interactive blog problem boards near the
+  viewport, avoid re-rendering static pieces on startup, and reuse one phantom
+  picker menu to improve large problem-post performance in Safari and Chrome.
+
 ## ks-home v. 1.2.11
 
 - **Blog**: made reading-time labels grammatically singular for one-minute

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/static/fen-board.js
+++ b/static/fen-board.js
@@ -29,25 +29,53 @@
   };
   var PHANTOM_PIECES = ["K", "Q", "R", "B", "N", "P", "k", "q", "r", "b", "n", "p"];
   var activeMenu = null;
+  var activeMenuDiagram = null;
+  var phantomMenu = null;
+  var lazyObserver = null;
 
   function init() {
-    document.querySelectorAll("[data-fen-diagram]").forEach(initDiagram);
+    document.querySelectorAll("[data-fen-diagram]").forEach(scheduleDiagramInit);
     document.addEventListener("click", handleDocumentClick);
     document.addEventListener("keydown", handleDocumentKeydown);
     window.addEventListener("resize", closeActiveMenu);
     window.addEventListener("scroll", closeActiveMenu, true);
   }
 
+  function scheduleDiagramInit(diagram) {
+    if (diagram.dataset.fenReady === "true" || diagram.dataset.fenQueued === "true") return;
+    if (!("IntersectionObserver" in window)) {
+      initDiagram(diagram);
+      return;
+    }
+
+    diagram.dataset.fenQueued = "true";
+    if (!lazyObserver) {
+      lazyObserver = new IntersectionObserver(handleLazyIntersections, {
+        rootMargin: "900px 0px",
+        threshold: 0.01
+      });
+    }
+    lazyObserver.observe(diagram);
+  }
+
+  function handleLazyIntersections(entries) {
+    entries.forEach(function (entry) {
+      if (!entry.isIntersecting && entry.intersectionRatio <= 0) return;
+      lazyObserver.unobserve(entry.target);
+      initDiagram(entry.target);
+    });
+  }
+
   function initDiagram(diagram) {
     if (diagram.dataset.fenReady === "true") return;
     diagram.dataset.fenReady = "true";
+    delete diagram.dataset.fenQueued;
     diagram.dataset.fenSelectedSquare = "";
     diagram.dataset.fenSelectedKind = "";
     diagram.dataset.fenLastMove = "";
 
-    createPhantomMenu(diagram);
     diagram.querySelectorAll("[data-fen-square]").forEach(function (square) {
-      renderSquare(square);
+      syncSquareState(square);
       square.addEventListener("click", function (event) {
         handleSquareClick(diagram, square, event);
       });
@@ -246,7 +274,9 @@
     closeActiveMenu();
   }
 
-  function createPhantomMenu(diagram) {
+  function getPhantomMenu() {
+    if (phantomMenu) return phantomMenu;
+
     var menu = document.createElement("div");
     menu.className = "fen-phantom-menu";
     menu.hidden = true;
@@ -272,6 +302,11 @@
       if (!button || !menu.contains(button)) return;
       event.stopPropagation();
 
+      var diagram = activeMenuDiagram;
+      if (!diagram) {
+        closeActiveMenu();
+        return;
+      }
       var square = findSquare(diagram, menu.dataset.fenTargetSquare || "");
       var piece = button.dataset.fenPhantomChoice || "";
       if (square && canPlacePhantom(square) && PIECE_ASSETS[piece]) {
@@ -281,15 +316,15 @@
       closeActiveMenu();
     });
 
-    diagram.appendChild(menu);
-    return menu;
+    document.body.appendChild(menu);
+    phantomMenu = menu;
+    return phantomMenu;
   }
 
   function openPhantomMenu(diagram, square, event) {
     if (!canPlacePhantom(square)) return;
     closeActiveMenu();
-    var menu = diagram.querySelector("[data-fen-phantom-menu]");
-    if (!menu) menu = createPhantomMenu(diagram);
+    var menu = getPhantomMenu();
 
     menu.dataset.fenTargetSquare = square.dataset.square || "";
     menu.hidden = false;
@@ -305,6 +340,7 @@
     menu.style.top = top + "px";
     menu.style.visibility = "";
     activeMenu = menu;
+    activeMenuDiagram = diagram;
 
     var firstButton = menu.querySelector("[data-fen-phantom-choice]");
     if (firstButton) firstButton.focus({ preventScroll: true });
@@ -372,6 +408,7 @@
     activeMenu.hidden = true;
     activeMenu.dataset.fenTargetSquare = "";
     activeMenu = null;
+    activeMenuDiagram = null;
   }
 
   function findSquare(diagram, squareName) {
@@ -387,10 +424,19 @@
       piece.remove();
     });
 
-    if (square.dataset.piece) square.dataset.phantomPiece = "";
+    syncSquareState(square);
 
     if (square.dataset.phantomPiece) {
       square.appendChild(createPiece(square.dataset.phantomPiece, "phantom"));
+    }
+
+    if (square.dataset.piece) square.appendChild(createPiece(square.dataset.piece, "piece"));
+  }
+
+  function syncSquareState(square) {
+    if (square.dataset.piece) square.dataset.phantomPiece = "";
+
+    if (square.dataset.phantomPiece) {
       square.dataset.fenPhantom = "true";
       square.classList.add("square--phantom");
     } else {
@@ -398,7 +444,6 @@
       square.classList.remove("square--phantom");
     }
 
-    if (square.dataset.piece) square.appendChild(createPiece(square.dataset.piece, "piece"));
     square.setAttribute("aria-label", squareLabel(square));
   }
 

--- a/tests/fen-board-script.test.mjs
+++ b/tests/fen-board-script.test.mjs
@@ -52,3 +52,35 @@ test("FEN board script deselects instead of removing on same-square clicks", () 
   assert.ok(script.includes("if (selectedSquareName === square.dataset.square) {\n        clearSelection(diagram);\n      } else {"));
   assert.ok(!script.includes("if (selectedSquareName === square.dataset.square) {\n        removePiece(square, selectedKind);"));
 });
+
+test("FEN board script lazy-initializes problem boards near the viewport", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes('document.querySelectorAll("[data-fen-diagram]").forEach(scheduleDiagramInit)'));
+  assert.ok(script.includes('new IntersectionObserver(handleLazyIntersections, {'));
+  assert.ok(script.includes('rootMargin: "900px 0px"'));
+  assert.ok(script.includes('lazyObserver.observe(diagram)'));
+  assert.ok(script.includes('lazyObserver.unobserve(entry.target)'));
+  assert.ok(script.includes('initDiagram(entry.target)'));
+});
+
+test("FEN board script avoids startup piece re-rendering", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("function syncSquareState(square)"));
+  assert.ok(script.includes("syncSquareState(square);"));
+  assert.ok(script.includes("function renderSquare(square)"));
+  assert.ok(!script.includes("renderSquare(square);\n      square.addEventListener(\"click\""));
+});
+
+test("FEN board script reuses one shared phantom menu", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("var phantomMenu = null;"));
+  assert.ok(script.includes("function getPhantomMenu()"));
+  assert.ok(script.includes("document.body.appendChild(menu);"));
+  assert.ok(script.includes("activeMenuDiagram = diagram;"));
+  assert.ok(script.includes("activeMenuDiagram = null;"));
+  assert.ok(!script.includes("createPhantomMenu(diagram)"));
+  assert.ok(!script.includes("diagram.appendChild(menu)"));
+});

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -21,7 +21,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="canonical" href="https://kriegspiel.org/" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.11" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.12" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes(".fen-board{width:22rem;max-width:100%;}"));


### PR DESCRIPTION
## Summary
- Lazy-initialize interactive FEN problem boards with `IntersectionObserver` so large blog posts do not wire up every off-screen board at page load.
- Avoid re-rendering static piece DOM during board startup; startup now syncs state and event handlers instead of recreating already-rendered pieces.
- Reuse one shared phantom picker menu instead of creating a menu per board.
- Bump ks-home to v1.2.12.

## Why
The La Scacchiera problems post currently contains 82 interactive boards, 5,248 squares, and 1,279 piece images. Safari and Chrome appear to pay a larger startup/paint cost than Firefox for this many interactive SVG-backed board nodes.

## Validation
- `node scripts/lint.mjs`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node --test tests/*.mjs` (48 passing)
- `PATH=node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/fil/.codex/tmp/arg0/codex-arg0fR8D3t:/Applications/Codex.app/Contents/Resources KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/run-tests.mjs` (lines 96.15%, branches 92.27%, functions 94.50%)
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/build.mjs`
- Local browser smoke at `http://127.0.0.1:4180/blog/la-scacchiera-invisibile-problems/`: page loaded with no console errors, first viewport initialized lazily, piece move worked, phantom placement worked, and only one phantom menu existed in DOM.