### PR TITLE
[codex] Speed up problem board dragging

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,13 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.13
+
+- **Problem Boards**: reduced drag/move work by caching board squares, skipping
+  repeated drag-target DOM writes, moving existing piece nodes instead of
+  recreating SVG images, and using a tiny transparent drag image for smoother
+  Chrome/Safari dragging.
+
 ## ks-home v. 1.2.12
 
 - **Problem Boards**: lazy-initialize interactive blog problem boards near the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/static/fen-board.js
+++ b/static/fen-board.js
@@ -32,6 +32,7 @@
   var activeMenuDiagram = null;
   var phantomMenu = null;
   var lazyObserver = null;
+  var transparentDragImage = null;
 
   function init() {
     document.querySelectorAll("[data-fen-diagram]").forEach(scheduleDiagramInit);
@@ -73,8 +74,11 @@
     diagram.dataset.fenSelectedSquare = "";
     diagram.dataset.fenSelectedKind = "";
     diagram.dataset.fenLastMove = "";
+    diagram.dataset.fenDragTargetSquare = "";
+    diagram.fenSquareMap = Object.create(null);
 
     diagram.querySelectorAll("[data-fen-square]").forEach(function (square) {
+      if (square.dataset.square) diagram.fenSquareMap[square.dataset.square] = square;
       syncSquareState(square);
       square.addEventListener("click", function (event) {
         handleSquareClick(diagram, square, event);
@@ -161,9 +165,13 @@
 
     selectSquare(diagram, square, payload.kind);
     diagram.dataset.fenDropHandled = "false";
+    diagram.dataset.fenDragging = "true";
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("application/x-ks-fen-piece", JSON.stringify(payload));
     event.dataTransfer.setData("text/plain", payload.kind + ":" + payload.square);
+    if (event.dataTransfer.setDragImage) {
+      event.dataTransfer.setDragImage(getTransparentDragImage(), 0, 0);
+    }
   }
 
   function handleDragOver(event) {
@@ -172,6 +180,7 @@
     if (!square || !diagram.contains(square)) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = "move";
+    if (diagram.dataset.fenDragTargetSquare === square.dataset.square) return;
     markDragTarget(diagram, square);
   }
 
@@ -198,6 +207,7 @@
     var diagram = event.currentTarget;
     var dropHandled = diagram.dataset.fenDropHandled === "true";
     delete diagram.dataset.fenDropHandled;
+    delete diagram.dataset.fenDragging;
     clearDragTargets(diagram);
 
     if (dropHandled) return;
@@ -235,16 +245,20 @@
       clearSelection(diagram);
       return;
     }
+    if (fromSquare === toSquare) {
+      clearSelection(diagram);
+      return;
+    }
     if (kind === "phantom" && !canPlacePhantom(toSquare)) {
       clearSelection(diagram);
       return;
     }
 
+    var movingNode = findPieceNode(fromSquare, kind);
     fromSquare.dataset[dataKey] = "";
     toSquare.dataset[dataKey] = piece;
     if (kind !== "phantom") toSquare.dataset.phantomPiece = "";
-    renderSquare(fromSquare);
-    renderSquare(toSquare);
+    movePieceNode(fromSquare, toSquare, movingNode);
     markLastMove(diagram, fromSquare, toSquare);
     clearSelection(diagram);
   }
@@ -355,8 +369,19 @@
   }
 
   function clearSelection(diagram) {
+    var selectedSquareName = diagram.dataset.fenSelectedSquare || "";
     diagram.dataset.fenSelectedSquare = "";
     diagram.dataset.fenSelectedKind = "";
+    var selectedSquare = findSquare(diagram, selectedSquareName);
+    if (!selectedSquare) {
+      clearAllSelections(diagram);
+      return;
+    }
+    delete selectedSquare.dataset.fenSelected;
+    selectedSquare.classList.remove("square--highlighted");
+  }
+
+  function clearAllSelections(diagram) {
     diagram.querySelectorAll("[data-fen-selected]").forEach(function (square) {
       delete square.dataset.fenSelected;
       square.classList.remove("square--highlighted");
@@ -379,20 +404,27 @@
   }
 
   function markDragTarget(diagram, square) {
-    diagram.querySelectorAll("[data-fen-drag-over]").forEach(function (target) {
-      if (target !== square) {
-        delete target.dataset.fenDragOver;
-        target.classList.remove("square--suggested");
-      }
-    });
+    var previousSquare = findSquare(diagram, diagram.dataset.fenDragTargetSquare || "");
+    if (previousSquare && previousSquare !== square) {
+      delete previousSquare.dataset.fenDragOver;
+      previousSquare.classList.remove("square--suggested");
+    }
+    diagram.dataset.fenDragTargetSquare = square.dataset.square || "";
     square.dataset.fenDragOver = "true";
     square.classList.add("square--suggested");
   }
 
   function clearDragTargets(diagram) {
-    diagram.querySelectorAll("[data-fen-drag-over]").forEach(function (square) {
+    var square = findSquare(diagram, diagram.dataset.fenDragTargetSquare || "");
+    diagram.dataset.fenDragTargetSquare = "";
+    if (square) {
       delete square.dataset.fenDragOver;
       square.classList.remove("square--suggested");
+      return;
+    }
+    diagram.querySelectorAll("[data-fen-drag-over]").forEach(function (target) {
+      delete target.dataset.fenDragOver;
+      target.classList.remove("square--suggested");
     });
   }
 
@@ -412,11 +444,9 @@
   }
 
   function findSquare(diagram, squareName) {
-    var result = null;
-    diagram.querySelectorAll("[data-fen-square]").forEach(function (square) {
-      if (square.dataset.square === squareName) result = square;
-    });
-    return result;
+    if (!squareName) return null;
+    if (diagram.fenSquareMap && diagram.fenSquareMap[squareName]) return diagram.fenSquareMap[squareName];
+    return diagram.querySelector('[data-square="' + squareName + '"]');
   }
 
   function renderSquare(square) {
@@ -431,6 +461,24 @@
     }
 
     if (square.dataset.piece) square.appendChild(createPiece(square.dataset.piece, "piece"));
+  }
+
+  function findPieceNode(square, kind) {
+    return square.querySelector('[data-fen-piece-kind="' + kind + '"]');
+  }
+
+  function movePieceNode(fromSquare, toSquare, movingNode) {
+    syncSquareState(fromSquare);
+    syncSquareState(toSquare);
+    if (!movingNode) {
+      renderSquare(fromSquare);
+      renderSquare(toSquare);
+      return;
+    }
+    toSquare.querySelectorAll(".fen-board__piece").forEach(function (piece) {
+      piece.remove();
+    });
+    toSquare.appendChild(movingNode);
   }
 
   function syncSquareState(square) {
@@ -467,6 +515,22 @@
     image.draggable = false;
     span.appendChild(image);
     return span;
+  }
+
+  function getTransparentDragImage() {
+    if (transparentDragImage) return transparentDragImage;
+    transparentDragImage = document.createElement("canvas");
+    transparentDragImage.width = 1;
+    transparentDragImage.height = 1;
+    transparentDragImage.style.position = "fixed";
+    transparentDragImage.style.left = "-10px";
+    transparentDragImage.style.top = "-10px";
+    transparentDragImage.style.width = "1px";
+    transparentDragImage.style.height = "1px";
+    transparentDragImage.style.opacity = "0";
+    transparentDragImage.style.pointerEvents = "none";
+    document.body.appendChild(transparentDragImage);
+    return transparentDragImage;
   }
 
   function pieceClassName(piece, kind) {

--- a/tests/fen-board-script.test.mjs
+++ b/tests/fen-board-script.test.mjs
@@ -84,3 +84,31 @@ test("FEN board script reuses one shared phantom menu", () => {
   assert.ok(!script.includes("createPhantomMenu(diagram)"));
   assert.ok(!script.includes("diagram.appendChild(menu)"));
 });
+
+test("FEN board script optimizes drag target updates", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("diagram.fenSquareMap = Object.create(null);"));
+  assert.ok(script.includes("diagram.fenSquareMap[square.dataset.square] = square;"));
+  assert.ok(script.includes("if (diagram.dataset.fenDragTargetSquare === square.dataset.square) return;"));
+  assert.ok(script.includes("var previousSquare = findSquare(diagram, diagram.dataset.fenDragTargetSquare || \"\");"));
+  assert.ok(script.includes("diagram.dataset.fenDragTargetSquare = square.dataset.square || \"\";"));
+});
+
+test("FEN board script moves existing piece nodes instead of recreating them", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("var movingNode = findPieceNode(fromSquare, kind);"));
+  assert.ok(script.includes("function movePieceNode(fromSquare, toSquare, movingNode)"));
+  assert.ok(script.includes("toSquare.appendChild(movingNode);"));
+  assert.ok(script.includes("if (fromSquare === toSquare) {"));
+});
+
+test("FEN board script uses a lightweight drag image", () => {
+  const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
+
+  assert.ok(script.includes("event.dataTransfer.setDragImage(getTransparentDragImage(), 0, 0);"));
+  assert.ok(script.includes("function getTransparentDragImage()"));
+  assert.ok(script.includes('transparentDragImage = document.createElement("canvas");'));
+  assert.ok(script.includes("transparentDragImage.width = 1;"));
+});

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -21,7 +21,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="canonical" href="https://kriegspiel.org/" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.12" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.13" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes(".fen-board{width:22rem;max-width:100%;}"));


### PR DESCRIPTION
## Summary
- Cache FEN board squares per diagram so move/drop lookup no longer scans all board squares.
- Skip repeated drag-target DOM writes when Chrome/Safari fire many `dragover` events on the same square.
- Move the existing piece DOM node on drop instead of recreating SVG image nodes.
- Use a tiny transparent canvas as the native drag image to avoid expensive browser-generated SVG drag ghosts.
- Bump ks-home to v1.2.13.

## Why
The previous lazy-init pass helped page startup, but the reported problem is drag/move responsiveness. Native HTML drag/drop can be especially slow in Chrome/Safari when it repeatedly repaints SVG drag images and highlight state.

## Validation
- `node scripts/lint.mjs`
- `node --check static/fen-board.js`
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node --test tests/*.mjs` (51 passing)
- `PATH=node_modules/.bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/fil/.codex/tmp/arg0/codex-arg0lYRyzf:/Users/fil/.local/bin:/opt/homebrew/opt/node@22/bin:/Applications/Codex.app/Contents/Resources KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/run-tests.mjs` (lines 96.15%, branches 92.27%, functions 94.50%)
- `KS_CONTENT_PATH=/Users/fil/Developer/kriegspiel/_wroktrees/content-validation-master node scripts/build.mjs`