### PR TITLE
Update blog snippet test for prefix-free bot API

### DIFF
--- a/scripts/test-blog-snippet-includes.mjs
+++ b/scripts/test-blog-snippet-includes.mjs
@@ -8,7 +8,7 @@ const html = fs.readFileSync(path.join(process.cwd(), "dist/blog/bot-registratio
 assert.match(html, /<figcaption>register-bot-request\.sh<\/figcaption>/);
 assert.match(html, /<figcaption>register-bot-response\.json<\/figcaption>/);
 assert.match(html, /<code class="hljs language-bash">/);
-assert.match(html, /curl -X POST https:\/\/api\.kriegspiel\.org\/api\/auth\/bots\/register/);
+assert.match(html, /curl -X POST https:\/\/api\.kriegspiel\.org\/auth\/bots\/register/);
 assert.match(html, /<code class="hljs language-json">/);
 assert.match(html, /ksbot_abcd1234\.deadbeef/);
 console.log("snippet include test: ok");


### PR DESCRIPTION
## Summary
- Updates the blog snippet include smoke test to match the current prefix-free bot registration endpoint in the content repo.
- Verified the generated Darkboard review blog route from Kriegspiel/content#94 includes the bot repo link and wild16 rule-set language.

## Rationale
The site build consumes content from the content repo. Current content already uses https://api.kriegspiel.org/auth/bots/register, but this assertion still expected the older /api/auth/bots/register path, causing the refresh validation to fail.

## Tests
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run build
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run lint
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run test
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run routes:validate
- npm run content:source-contract:check
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run content:schema:check
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run test:smoke
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run test:snippets
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run structured-data:check
- KS_CONTENT_PATH=/home/ubuntu/dev/kriegspiel/_wroktrees/content-darkboard-review npm run seo:validate

## Deployment notes
No version bump: test-only/static-refresh validation change. After content merge, rebuild/deploy ks-home so /blog/darkboard-kriegspiel-engine-review is published.