### PR TITLE
Normalize footer RSS link order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.15",
+      "version": "1.2.16",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -39,7 +39,7 @@ function parseFooterEntry(footerEntry) {
 function renderFooter(footerEntry) {
   const fallbackGroups = [
     { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/english', 'English'], ['/rules/crazykrieg', 'CrazyKrieg'], ['/rules/comparison/', 'Comparison']] },
-    { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/', 'About']] },
+    { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/feed.xml', 'RSS'], ['/about', 'About']] },
     { title: 'Social', links: [['https://x.com/kriegspiel_org', 'X.com (@kriegspiel_org)'], ['https://github.com/Kriegspiel', 'GitHub']] }
   ];
   const groups = withFeedFooterLink(footerEntry ? parseFooterEntry(footerEntry) : fallbackGroups);
@@ -48,13 +48,17 @@ function renderFooter(footerEntry) {
 
 function withFeedFooterLink(groups = []) {
   const cloned = groups.map((group) => ({ title: group.title, links: Array.isArray(group.links) ? [...group.links] : [] }));
-  if (cloned.some((group) => group.links.some(([href]) => href === '/feed.xml'))) return cloned;
   const communication = cloned.find((group) => String(group.title).toLowerCase() === 'communication');
-  if (communication) {
-    communication.links.push(['/feed.xml', 'RSS']);
-  } else {
-    cloned.push({ title: 'Communication', links: [['/blog', 'Blog'], ['/feed.xml', 'RSS']] });
+  if (!communication) {
+    cloned.push({ title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/feed.xml', 'RSS'], ['/about', 'About']] });
+    return cloned;
   }
+
+  const existingFeedLink = communication.links.find(([href]) => href === '/feed.xml') || ['/feed.xml', 'RSS'];
+  const linksWithoutFeed = communication.links.filter(([href]) => href !== '/feed.xml');
+  const aboutIndex = linksWithoutFeed.findIndex(([href, label]) => href === '/about' || (href === '/' && label === 'About'));
+  linksWithoutFeed.splice(aboutIndex === -1 ? linksWithoutFeed.length : aboutIndex, 0, existingFeedLink);
+  communication.links = linksWithoutFeed;
   return cloned;
 }
 

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -8,6 +8,10 @@ import {
   renderShell,
 } from "../src/pages.mjs";
 
+function footerGroupHtml(html, label) {
+  return html.match(new RegExp(`<section class="footer__group" aria-label="${label}">[\\s\\S]*?</section>`))?.[0] ?? "";
+}
+
 test("renderShell falls back canonical paths and footer variants", () => {
   const emptyFooterHtml = renderShell({
     title: "Demo shell",
@@ -23,7 +27,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="alternate" type="application/atom+xml" title="Kriegspiel Updates Atom" href="https://kriegspiel.org/atom.xml" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.15" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.16" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes(".fen-board{width:22rem;max-width:100%;}"));
@@ -54,6 +58,20 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(fallbackFooterHtml.includes(">Communication</h2>"));
   assert.ok(fallbackFooterHtml.includes('<a href="/feed.xml">RSS</a>'));
   assert.ok(fallbackFooterHtml.includes(">Social</h2>"));
+
+  const communicationFooter = footerGroupHtml(fallbackFooterHtml, "Communication");
+  assert.ok(communicationFooter.includes('<a href="/blog">Blog</a></li><li><a href="/changelog">Changelog</a></li><li><a href="/feed.xml">RSS</a></li><li><a href="/about">About</a>'));
+
+  const legacyFooterHtml = renderShell({
+    title: "Legacy footer shell",
+    description: "Footer description",
+    main: "<p>hello</p>",
+    footerEntry: {
+      body: "# Communication\n- [Blog](/blog)\n- [Changelog](/changelog)\n- [About](/about)\n",
+    },
+  });
+  const legacyCommunicationFooter = footerGroupHtml(legacyFooterHtml, "Communication");
+  assert.ok(legacyCommunicationFooter.includes('<a href="/blog">Blog</a></li><li><a href="/changelog">Changelog</a></li><li><a href="/feed.xml">RSS</a></li><li><a href="/about">About</a>'));
 });
 
 test("home page falls back when content is sparse or missing metadata wrappers", () => {


### PR DESCRIPTION
Summary
- Render Communication footer links as Blog, Changelog, RSS, About.
- Normalize legacy footer content so RSS is inserted before About instead of appended.
- Bump ks-home to 1.2.16 and cover the footer order in tests.

Rationale
kriegspiel.org should expose the RSS feed in the requested footer order and keep fallback/legacy footer rendering aligned.

Tests
- npm run lint
- node --test tests/pages-branches.test.mjs
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/content-footer-rss-order npm run build

Deployment notes
After merge, refresh the deployed ks-home checkout/build for kriegspiel.org. No backend or app service restart is needed for the static-site change.

Verified commit: 100bfd90730aa3944c8536faf854b1267797e6aa