### PR TITLE
Require ks-content as website content source

### DIFF
--- a/scripts/content-trigger-simulate.mjs
+++ b/scripts/content-trigger-simulate.mjs
@@ -5,8 +5,7 @@ import { execSync } from "node:child_process";
 
 const fromArg = process.argv.find((arg) => arg.startsWith("--from="));
 const verify = process.argv.includes("--verify-static-regen");
-const defaultFromPath = fs.existsSync(path.resolve(process.cwd(), "../ks-content")) ? "../ks-content" : "../content";
-const fromPath = fromArg ? fromArg.split("=")[1] : defaultFromPath;
+const fromPath = fromArg ? fromArg.split("=")[1] : "../ks-content";
 assert.ok(fs.existsSync(path.resolve(process.cwd(), fromPath)), `missing content path ${fromPath}`);
 execSync("node scripts/build.mjs", { stdio: "pipe", env: { ...process.env, KS_CONTENT_PATH: fromPath } });
 const manifest = JSON.parse(fs.readFileSync(path.join(process.cwd(), "dist/.regen-manifest.json"), "utf8"));

--- a/scripts/refresh-static-site.sh
+++ b/scripts/refresh-static-site.sh
@@ -4,9 +4,6 @@ set -euo pipefail
 ROOT="${ROOT:-/home/fil/dev/kriegspiel}"
 KS_HOME_REPO="${KS_HOME_REPO:-$ROOT/ks-home}"
 CONTENT_REPO="${CONTENT_REPO:-$ROOT/ks-content}"
-if [[ ! -d "$CONTENT_REPO/.git" && -d "$ROOT/content/.git" ]]; then
-  CONTENT_REPO="$ROOT/content"
-fi
 WORK_ROOT="${WORK_ROOT:-$ROOT/.site-refresh}"
 KS_API_BASE="${KS_API_BASE:-https://api.kriegspiel.org}"
 HOME_BRANCH="${HOME_BRANCH:-master}"

--- a/src/content-utils.mjs
+++ b/src/content-utils.mjs
@@ -585,9 +585,7 @@ export function validateEntry(entry) {
 }
 
 function defaultContentRoot() {
-  const canonicalRoot = path.resolve(process.cwd(), "../ks-content");
-  if (fs.existsSync(canonicalRoot)) return canonicalRoot;
-  return path.resolve(process.cwd(), "../content");
+  return path.resolve(process.cwd(), "../ks-content");
 }
 
 export function getContentRoot() { return path.resolve(process.cwd(), process.env.KS_CONTENT_PATH || defaultContentRoot()); }

--- a/tests/content-utils-branches.test.mjs
+++ b/tests/content-utils-branches.test.mjs
@@ -99,23 +99,18 @@ test("markdownToHtml covers include-code aliases, unknown extensions, and guardr
   }
 });
 
-test("getContentRoot prefers ks-content sibling and falls back to legacy content", () => {
+test("getContentRoot uses the ks-content sibling by default", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ks-home-content-root-"));
   const previousContentPath = process.env.KS_CONTENT_PATH;
   const previousCwd = process.cwd();
 
   try {
     const homeRoot = path.join(tempRoot, "ks-home");
-    const legacyRoot = path.join(tempRoot, "content");
     const canonicalRoot = path.join(tempRoot, "ks-content");
     fs.mkdirSync(homeRoot);
-    fs.mkdirSync(legacyRoot);
     delete process.env.KS_CONTENT_PATH;
 
     process.chdir(homeRoot);
-    assert.equal(getContentRoot(), legacyRoot);
-
-    fs.mkdirSync(canonicalRoot);
     assert.equal(getContentRoot(), canonicalRoot);
   } finally {
     process.chdir(previousCwd);


### PR DESCRIPTION
## Summary
- default website content resolution to sibling `../ks-content`
- remove the refresh script fallback to `$ROOT/content`
- update trigger simulation and content-root tests for the canonical repo name

## Rationale
The content repo rename is complete; `ks-home` should require the migrated checkout instead of supporting both layouts.

## Tests
- `npm run content:schema:check`
- `npm run content:source-contract:check`
- `npm run test -- --runInBand --watch=false` (56 tests)
- `KS_API_BASE=https://api.kriegspiel.org npm run build`
- hard old-path search returned no matches for legacy content fallback patterns

## Deployment notes
Production must have `/home/ubuntu/dev/kriegspiel/ks-content` before this is deployed. Restart `ks-home.service` after build.