### PR TITLE
Remove Dutch from public footer fallback

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.21
+
+- **Footer Rules Links**: remove the incomplete Dutch ruleset from the public
+  footer while keeping the full rules page and comparison material available.
+
 ## ks-home v. 1.2.18
 
 - **English Rules**: clarify that English en-passant captures are announced

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -38,7 +38,7 @@ function parseFooterEntry(footerEntry) {
 
 function renderFooter(footerEntry) {
   const fallbackGroups = [
-    { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/english', 'English'], ['/rules/crazykrieg', 'CrazyKrieg'], ['/rules/dutch', 'Dutch'], ['/rules/comparison/', 'Comparison']] },
+    { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/english', 'English'], ['/rules/crazykrieg', 'CrazyKrieg'], ['/rules/comparison/', 'Comparison']] },
     { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/feed.xml', 'RSS'], ['/about', 'About']] },
     { title: 'Social', links: [['https://x.com/kriegspiel_org', 'X.com (@kriegspiel_org)'], ['https://github.com/Kriegspiel', 'GitHub']] }
   ];

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -27,7 +27,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="alternate" type="application/atom+xml" title="Kriegspiel Updates Atom" href="https://kriegspiel.org/atom.xml" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.20" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.21" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes(".fen-board{width:22rem;max-width:100%;}"));
@@ -55,7 +55,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
     main: "<p>hello</p>",
   });
   assert.ok(fallbackFooterHtml.includes(">Rules</h2>"));
-  assert.ok(fallbackFooterHtml.includes('<a href="/rules/dutch">Dutch</a>'));
+  assert.ok(!fallbackFooterHtml.includes('<a href="/rules/dutch">Dutch</a>'));
   assert.ok(fallbackFooterHtml.includes(">Communication</h2>"));
   assert.ok(fallbackFooterHtml.includes('<a href="/feed.xml">RSS</a>'));
   assert.ok(fallbackFooterHtml.includes(">Social</h2>"));


### PR DESCRIPTION
## Summary
- Remove the Dutch ruleset link from the public-site fallback footer list.
- Bump `ks-home` to `1.2.21` and add release notes.
- Update the fallback footer regression test.

## Rationale
The canonical shared footer is being updated in Kriegspiel/ks-content#121. This keeps the public site fallback path aligned so Dutch does not reappear if the shared footer content is unavailable.

## Tests
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-dutch-footer npm test`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-dutch-footer npm run build`
- `node -e 'const fs=require("fs"); for (const file of ["dist/index.html","dist/rules/index.html","dist/rules/comparison/index.html"]) { const html=fs.readFileSync(file,"utf8"); const footer=html.match(/<footer[\\s\\S]*?<\\/footer>/)?.[0] || ""; if (/Dutch|\\/rules\\/dutch/.test(footer)) { console.error(`${file}: Dutch still present in footer`); process.exitCode=1; } else { console.log(`${file}: footer ok`); } }'`
- App-side verification against ks-content commit `344053edd8d4efe0c1e469d7b1144e70eb85ef7e`: `npm test -- --run src/__tests__/AppFooter.test.jsx`, `npm run build`, and `rg -n "Dutch|rules/dutch" dist || true` returned no matches.

## Deployment Notes
- Merge after Kriegspiel/ks-content#121 or deploy with that content commit available.
- Fast-forward/rebuild/redeploy `ks-home` to publish the public footer update.
- Rebuild/redeploy `ks-web-app` as part of the same content refresh because the app footer consumes the shared footer markdown at build time.
