### PR TITLE
Handle stale static refresh worktrees

### DIFF
--- a/scripts/refresh-static-site.sh
+++ b/scripts/refresh-static-site.sh
@@ -24,6 +24,19 @@ ensure_worktree() {
 
   git -C "$repo" fetch origin "$branch"
 
+  if [[ -e "$worktree" ]] && ! git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    case "$worktree" in
+      "$WORK_ROOT"/*)
+        rm -rf -- "$worktree"
+        git -C "$repo" worktree prune
+        ;;
+      *)
+        echo "Refusing to remove unmanaged worktree path: $worktree" >&2
+        exit 2
+        ;;
+    esac
+  fi
+
   if [[ ! -d "$worktree" ]]; then
     git -C "$repo" worktree add --detach "$worktree" "origin/$branch"
   else


### PR DESCRIPTION
## Summary
- make the static refresh script discard broken generated worktree directories under the managed refresh root
- prune current repo worktree metadata before recreating the generated worktree

## Rationale
The production refresh job can fail when a generated worktree has a stale .git pointer from the previous content repo path. The script should recover by deleting only the managed generated worktree path and recreating it from the current repo.

## Tests
- bash -n scripts/refresh-static-site.sh
- targeted refresh-script simulation with a stale ks-content-master .git pointer
- npm run lint
- npm test
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/ks-content npm run build

## Deployment notes
Operational ks-home script fix. Deploy with ks-deploy home, then rerun ks-deploy content to confirm the content refresh path succeeds. No package version bump: no user-visible static-site content or runtime app behavior changed.