### PR TITLE
[codex] Allow phantom captures on problem boards

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,12 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.24
+
+- **Problem Boards**: allow moved phantom pieces to capture real pieces during
+  scratch-board exploration, while keeping new phantom placement limited to
+  empty squares.
+
 ## ks-home v. 1.2.23
 
 - **Problem Boards**: add undo and redo arrow controls for scratch-board

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.23",
+      "version": "1.2.24",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/static/fen-board.js
+++ b/static/fen-board.js
@@ -285,13 +285,15 @@
       clearSelection(diagram);
       return;
     }
-    if (kind === "phantom" && !canPlacePhantom(toSquare)) {
+    var capturedPiece = kind === "phantom" ? (toSquare.dataset.piece || "") : "";
+    if (kind === "phantom" && !canPlacePhantom(toSquare) && !capturedPiece) {
       clearSelection(diagram);
       return;
     }
 
     var movingNode = findPieceNode(fromSquare, kind);
     fromSquare.dataset[dataKey] = "";
+    if (kind === "phantom" && capturedPiece) toSquare.dataset.piece = "";
     toSquare.dataset[dataKey] = piece;
     if (kind !== "phantom") toSquare.dataset.phantomPiece = "";
     movePieceNode(fromSquare, toSquare, movingNode);

--- a/tests/fen-board-script.test.mjs
+++ b/tests/fen-board-script.test.mjs
@@ -25,12 +25,14 @@ test("FEN board script renders pieces with live-board class aliases", () => {
   assert.ok(script.includes('"fen-board__piece-image piece__image"'));
 });
 
-test("FEN board script keeps phantoms off occupied squares", () => {
+test("FEN board script keeps new phantoms off occupied squares while moved phantoms capture", () => {
   const script = fs.readFileSync(path.join(process.cwd(), "static", "fen-board.js"), "utf8");
 
   assert.ok(script.includes("function canPlacePhantom(square)"));
   assert.ok(script.includes('if (!canPlacePhantom(square)) {'));
-  assert.ok(script.includes('if (kind === "phantom" && !canPlacePhantom(toSquare))'));
+  assert.ok(script.includes('var capturedPiece = kind === "phantom" ? (toSquare.dataset.piece || "") : "";'));
+  assert.ok(script.includes('if (kind === "phantom" && !canPlacePhantom(toSquare) && !capturedPiece)'));
+  assert.ok(script.includes('if (kind === "phantom" && capturedPiece) toSquare.dataset.piece = "";'));
   assert.ok(script.includes("square && canPlacePhantom(square) && PIECE_ASSETS[piece]"));
   assert.ok(script.includes("if (square.dataset.piece) square.dataset.phantomPiece = \"\";"));
 });

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -27,7 +27,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(emptyFooterHtml.includes('<link rel="alternate" type="application/atom+xml" title="Kriegspiel Updates Atom" href="https://kriegspiel.org/atom.xml" />'));
   assert.ok(emptyFooterHtml.includes('<meta property="og:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
   assert.ok(emptyFooterHtml.includes('<meta name="twitter:image" content="https://kriegspiel.org/social-card-20260511.png" />'));
-  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.23" defer></script>'));
+  assert.ok(emptyFooterHtml.includes('<script src="/fen-board.js?v=1.2.24" defer></script>'));
   assert.ok(emptyFooterHtml.includes("--square-capture-overlay:transparent"));
   assert.ok(emptyFooterHtml.includes("var(--square-ring-capture),var(--square-ring-illegal),var(--square-ring-suggested)"));
   assert.ok(emptyFooterHtml.includes(".fen-board{width:22rem;max-width:100%;user-select:none;-webkit-user-select:none;}"));


### PR DESCRIPTION
## Summary
- Allow an already-placed phantom piece to move onto and capture a real piece on problem-board diagrams.
- Keep new phantom placement limited to empty squares through the existing picker/context-menu guard.
- Bump `ks-home` to `1.2.24` and document the behavior change.

## Rationale
Scratch-board solving often needs to test a hypothetical invisible piece capturing a known unit. Undo/redo now restores board snapshots, so allowing moved phantoms to capture real pieces makes exploration more natural without making initial phantom placement ambiguous.

## Tests
- `npm ci`
- `npm test`
- `npm run lint`
- `npm run build`

Verified commit: `133c603`

## Deployment Notes
- Static-site change only: rebuild/deploy `ks-home`.
- No backend, API, or app frontend restart required.