### PR TITLE
[codex] add playing guide route

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.2.29
+
+- **Playing Guide**: add a short platform play guide at `/playing` and link it
+  from the Game footer column.
+
 ## ks-home v. 1.2.26
 
 - **Campaign Attribution**: load a privacy-minimal UTM capture script on static

--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -19,6 +19,14 @@
   ],
   "footerGroups": [
     {
+      "title": "Game",
+      "links": [
+        { "label": "Play online", "href": "https://app.kriegspiel.org/" },
+        { "label": "Playing here", "href": "/playing" },
+        { "label": "Leaderboard", "href": "/leaderboard" }
+      ]
+    },
+    {
       "title": "Policy",
       "links": [
         { "label": "Privacy", "href": "/privacy" },
@@ -46,13 +54,6 @@
       ]
     },
     {
-      "title": "Game",
-      "links": [
-        { "label": "Leaderboard", "href": "/leaderboard" },
-        { "label": "Play online", "href": "https://app.kriegspiel.org/" }
-      ]
-    },
-    {
       "title": "Development",
       "links": [
         { "label": "API docs", "href": "https://api.kriegspiel.org/docs" },
@@ -67,6 +68,9 @@
     }
   ],
   "footerLinks": [
+    { "label": "Play online", "href": "https://app.kriegspiel.org/" },
+    { "label": "Playing here", "href": "/playing" },
+    { "label": "Leaderboard", "href": "/leaderboard" },
     { "label": "Privacy", "href": "/privacy" },
     { "label": "Terms", "href": "/terms" },
     { "label": "Berkeley", "href": "/rules/berkeley" },
@@ -79,8 +83,6 @@
     { "label": "Blog", "href": "/blog" },
     { "label": "Changelog", "href": "/changelog" },
     { "label": "About", "href": "/about" },
-    { "label": "Leaderboard", "href": "/leaderboard" },
-    { "label": "Play online", "href": "https://app.kriegspiel.org/" },
     { "label": "API docs", "href": "https://api.kriegspiel.org/docs" },
     { "label": "GitHub", "href": "https://github.com/Kriegspiel" },
     { "label": "X.com", "href": "https://x.com/kriegspiel_org" }

--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -22,7 +22,7 @@
       "title": "Game",
       "links": [
         { "label": "Play online", "href": "https://app.kriegspiel.org/" },
-        { "label": "Playing here", "href": "/playing" },
+        { "label": "Playing guide", "href": "/playing" },
         { "label": "Leaderboard", "href": "/leaderboard" }
       ]
     },
@@ -69,7 +69,7 @@
   ],
   "footerLinks": [
     { "label": "Play online", "href": "https://app.kriegspiel.org/" },
-    { "label": "Playing here", "href": "/playing" },
+    { "label": "Playing guide", "href": "/playing" },
     { "label": "Leaderboard", "href": "/leaderboard" },
     { "label": "Privacy", "href": "/privacy" },
     { "label": "Terms", "href": "/terms" },

--- a/contracts/routes.json
+++ b/contracts/routes.json
@@ -5,6 +5,7 @@
     "/blog",
     "/changelog",
     "/rules",
+    "/playing",
     "/privacy",
     "/terms"
   ],

--- a/docs/release/launch-runbook.md
+++ b/docs/release/launch-runbook.md
@@ -29,7 +29,7 @@
 
 ```bash
 # from ks-home
-BASE_URL="https://kriegspiel.org" ./scripts/deploy/smoke.sh --routes "/,/leaderboard,/blog,/changelog,/rules"
+BASE_URL="https://kriegspiel.org" ./scripts/deploy/smoke.sh --routes "/,/leaderboard,/blog,/changelog,/rules,/playing"
 ```
 
 ## Failed Deploy Policy
@@ -39,7 +39,7 @@ If smoke fails after production cutover:
 2. Execute rollback immediately:
    ```bash
    ./scripts/deploy/rollback.sh --to previous
-   BASE_URL="https://kriegspiel.org" ./scripts/deploy/smoke.sh --routes "/,/leaderboard,/blog,/changelog,/rules"
+   BASE_URL="https://kriegspiel.org" ./scripts/deploy/smoke.sh --routes "/,/leaderboard,/blog,/changelog,/rules,/playing"
    ```
 3. Page release owner and engineering owner.
 4. Keep release frozen until root cause and remediation PR are approved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.28",
+      "version": "1.2.29",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -15,6 +15,7 @@ const homeEntry = loadSingletonEntry(contentRoot, 'site', 'home');
 const privacyEntry = loadSingletonEntry(contentRoot, 'site', 'privacy');
 const termsEntry = loadSingletonEntry(contentRoot, 'site', 'terms');
 const aboutEntry = loadSingletonEntry(contentRoot, 'site', 'about');
+const playingEntry = loadSingletonEntry(contentRoot, 'site', 'playing');
 const footerEntry = loadSingletonEntry(contentRoot, 'site', 'footer');
 const CHESS_PIECE_ASSETS = [
   'LICENSE.md',
@@ -96,6 +97,7 @@ writePage(path.join(dist, 'rules/comparison/index.html'), renderRulesComparisonP
 writePage(path.join(dist, 'privacy/index.html'), renderSiteMarkdownPage(privacyEntry, footerEntry));
 writePage(path.join(dist, 'terms/index.html'), renderSiteMarkdownPage(termsEntry, footerEntry));
 writePage(path.join(dist, 'about/index.html'), renderSiteMarkdownPage(aboutEntry, footerEntry));
+writePage(path.join(dist, 'playing/index.html'), renderSiteMarkdownPage(playingEntry, footerEntry));
 writePage(path.join(dist, '404.html'), renderSimplePage('Not Found', footerEntry));
 
 for (const entry of blogEntries) writePage(path.join(dist, 'blog', entry.metadata.slug, 'index.html'), renderBlogDetail(entry, footerEntry));
@@ -106,7 +108,7 @@ writePage(path.join(dist, 'rules/wild-16/index.html'), renderRedirectPage({ from
 
 const manifest = {
   generatedAt,
-  sourceHash: createHash('sha256').update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]), site: [[homeEntry.file, homeEntry.metadata.updatedAt], [privacyEntry.file, privacyEntry.metadata.updatedAt], [termsEntry.file, termsEntry.metadata.updatedAt], [aboutEntry.file, aboutEntry.metadata.updatedAt], [footerEntry.file, footerEntry.metadata.updatedAt]], players: publicData.entries.map((entry) => [entry.username, entry.rating, entry.gamesPlayed]) })).digest('hex'),
+  sourceHash: createHash('sha256').update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]), site: [[homeEntry.file, homeEntry.metadata.updatedAt], [privacyEntry.file, privacyEntry.metadata.updatedAt], [termsEntry.file, termsEntry.metadata.updatedAt], [aboutEntry.file, aboutEntry.metadata.updatedAt], [playingEntry.file, playingEntry.metadata.updatedAt], [footerEntry.file, footerEntry.metadata.updatedAt]], players: publicData.entries.map((entry) => [entry.username, entry.rating, entry.gamesPlayed]) })).digest('hex'),
   blogRoutes: blogEntries.map((entry) => `/blog/${entry.metadata.slug}`),
   changelogRoutes: changelogEntries.map((entry) => `/changelog/${entry.metadata.slug}`),
   ruleRoutes: ['/rules', '/rules/comparison', ...rulesEntries.map((entry) => `/rules/${entry.metadata.slug}`)],
@@ -121,7 +123,7 @@ writePage(path.join(dist, 'sitemap.xml'), renderSitemap(buildSitemapRoutes({
   blogEntries,
   changelogEntries,
   rulesEntries,
-  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry },
+  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry },
   playerRoutes: manifest.playerRoutes,
   generatedAt,
 })));

--- a/scripts/deploy/smoke.sh
+++ b/scripts/deploy/smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-}"
-ROUTES="/,/leaderboard,/blog,/changelog,/rules"
+ROUTES="/,/leaderboard,/blog,/changelog,/rules,/playing"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/seo-validate.mjs
+++ b/scripts/seo-validate.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/playing").split(",");
 
 const requiredChecks = [
   { name: "<title>", re: /<title>[^<]+<\/title>/i },

--- a/scripts/sitemap-generate.mjs
+++ b/scripts/sitemap-generate.mjs
@@ -12,13 +12,14 @@ const homeEntry = loadSingletonEntry(contentRoot, "site", "home");
 const privacyEntry = loadSingletonEntry(contentRoot, "site", "privacy");
 const termsEntry = loadSingletonEntry(contentRoot, "site", "terms");
 const aboutEntry = loadSingletonEntry(contentRoot, "site", "about");
+const playingEntry = loadSingletonEntry(contentRoot, "site", "playing");
 const manifestPath = path.join(process.cwd(), "dist/.regen-manifest.json");
 const manifest = fs.existsSync(manifestPath) ? JSON.parse(fs.readFileSync(manifestPath, "utf8")) : {};
 const xml = renderSitemap(buildSitemapRoutes({
   blogEntries,
   changelogEntries,
   rulesEntries,
-  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry },
+  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry },
   playerRoutes: Array.isArray(manifest.playerRoutes) ? manifest.playerRoutes : [],
   generatedAt: manifest.generatedAt || new Date().toISOString(),
 }));

--- a/scripts/structured-data-check.mjs
+++ b/scripts/structured-data-check.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const targets = ["/", "/blog", "/changelog", "/rules"];
+const targets = ["/", "/blog", "/changelog", "/rules", "/playing"];
 let failures = 0;
 for (const route of targets) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;

--- a/scripts/test-smoke-routes.mjs
+++ b/scripts/test-smoke-routes.mjs
@@ -6,7 +6,7 @@ import { execSync } from "node:child_process";
 execSync("node scripts/build.mjs", { stdio: "pipe" });
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/rules").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/rules,/playing").split(",");
 for (const route of routes) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;
   assert.ok(fs.existsSync(path.join(process.cwd(), "dist", rel)), `missing route ${route}`);

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -55,6 +55,7 @@ function renderFooterLink([href, label]) {
 
 function renderFooter(footerEntry) {
   const fallbackGroups = [
+    { title: 'Game', links: [['https://app.kriegspiel.org/', 'Play online'], ['/playing', 'Playing here'], ['/leaderboard', 'Leaderboard']] },
     { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/english', 'English'], ['/rules/crazykrieg', 'CrazyKrieg'], ['/rules/comparison/', 'Comparison']] },
     { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/feed.xml', 'RSS'], ['/about', 'About']] },
     { title: 'Development', links: [['https://api.kriegspiel.org/docs', 'API docs'], ['https://github.com/Kriegspiel', 'GitHub']] },

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -55,7 +55,7 @@ function renderFooterLink([href, label]) {
 
 function renderFooter(footerEntry) {
   const fallbackGroups = [
-    { title: 'Game', links: [['https://app.kriegspiel.org/', 'Play online'], ['/playing', 'Playing here'], ['/leaderboard', 'Leaderboard']] },
+    { title: 'Game', links: [['https://app.kriegspiel.org/', 'Play online'], ['/playing', 'Playing guide'], ['/leaderboard', 'Leaderboard']] },
     { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/english', 'English'], ['/rules/crazykrieg', 'CrazyKrieg'], ['/rules/comparison/', 'Comparison']] },
     { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/feed.xml', 'RSS'], ['/about', 'About']] },
     { title: 'Development', links: [['https://api.kriegspiel.org/docs', 'API docs'], ['https://github.com/Kriegspiel', 'GitHub']] },

--- a/src/site-feeds.mjs
+++ b/src/site-feeds.mjs
@@ -55,6 +55,7 @@ export function buildSitemapRoutes({
     { path: "/privacy", lastmod: siteEntries.privacy?.metadata?.updatedAt },
     { path: "/terms", lastmod: siteEntries.terms?.metadata?.updatedAt },
     { path: "/about", lastmod: siteEntries.about?.metadata?.updatedAt },
+    { path: "/playing", lastmod: siteEntries.playing?.metadata?.updatedAt },
     ...blogEntries.map((entry) => ({ path: `/blog/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),
     ...changelogEntries.map((entry) => ({ path: `/changelog/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),
     ...rulesEntries.map((entry) => ({ path: `/rules/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -6,7 +6,7 @@ import { execSync } from 'node:child_process';
 
 test('build emits required public pages', () => {
   execSync('node scripts/build.mjs', { stdio: 'pipe' });
-  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'privacy/index.html', 'terms/index.html']) {
+  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'playing/index.html', 'privacy/index.html', 'terms/index.html']) {
     assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', routeFile)), `missing ${routeFile}`);
   }
   assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', 'social-card-20260511.png')), 'missing social-card-20260511.png');
@@ -22,5 +22,6 @@ test('build emits required public pages', () => {
   assert.ok(feed.includes('<rss version="2.0"'));
   assert.ok(atom.includes('<feed xmlns="http://www.w3.org/2005/Atom"'));
   assert.ok(sitemap.includes('https://kriegspiel.org/rules/berkeley'));
+  assert.ok(sitemap.includes('https://kriegspiel.org/playing'));
   assert.ok(sitemap.includes('<lastmod>'));
 });

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -63,7 +63,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
     main: "<p>hello</p>",
   });
   assert.ok(fallbackFooterHtml.includes(">Game</h2>"));
-  assert.ok(fallbackFooterHtml.includes('<a href="/playing">Playing here</a>'));
+  assert.ok(fallbackFooterHtml.includes('<a href="/playing">Playing guide</a>'));
   assert.ok(fallbackFooterHtml.includes(">Rules</h2>"));
   assert.ok(!fallbackFooterHtml.includes('<a href="/rules/dutch">Dutch</a>'));
   assert.ok(fallbackFooterHtml.includes(">Communication</h2>"));

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -62,6 +62,8 @@ test("renderShell falls back canonical paths and footer variants", () => {
     description: "Fallback description",
     main: "<p>hello</p>",
   });
+  assert.ok(fallbackFooterHtml.includes(">Game</h2>"));
+  assert.ok(fallbackFooterHtml.includes('<a href="/playing">Playing here</a>'));
   assert.ok(fallbackFooterHtml.includes(">Rules</h2>"));
   assert.ok(!fallbackFooterHtml.includes('<a href="/rules/dutch">Dutch</a>'));
   assert.ok(fallbackFooterHtml.includes(">Communication</h2>"));

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -63,7 +63,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
     main: "<p>hello</p>",
   });
   assert.ok(fallbackFooterHtml.includes(">Game</h2>"));
-  assert.ok(fallbackFooterHtml.includes('<a href="/playing">Playing guide</a>'));
+  assert.ok(fallbackFooterHtml.includes('<a class="footer__link" href="/playing">Playing guide</a>'));
   assert.ok(fallbackFooterHtml.includes(">Rules</h2>"));
   assert.ok(!fallbackFooterHtml.includes('<a href="/rules/dutch">Dutch</a>'));
   assert.ok(fallbackFooterHtml.includes(">Communication</h2>"));

--- a/tests/routes-contract.test.mjs
+++ b/tests/routes-contract.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 const routes = JSON.parse(fs.readFileSync(new URL("../contracts/routes.json", import.meta.url), "utf8"));
 
 test("required route set includes public + trust pages", () => {
-  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/privacy", "/terms"]) {
+  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/playing", "/privacy", "/terms"]) {
     assert.ok(routes.requiredStaticRoutes.includes(route));
   }
 });

--- a/tests/site-feeds.test.mjs
+++ b/tests/site-feeds.test.mjs
@@ -72,6 +72,7 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
       privacy: { metadata: { updatedAt: "2026-03-28" } },
       terms: { metadata: { updatedAt: "2026-03-29" } },
       about: { metadata: { updatedAt: "2026-03-30" } },
+      playing: { metadata: { updatedAt: "2026-07-05" } },
     },
     playerRoutes: ["/players/refereefox", "/blog/research-map"],
     generatedAt: "2026-05-24T00:00:00.000Z",
@@ -81,6 +82,7 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
 
   const sitemap = renderSitemap(routes);
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/</loc><lastmod>2026-03-27</lastmod>"));
+  assert.ok(sitemap.includes("<loc>https://kriegspiel.org/playing</loc><lastmod>2026-07-05</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/rules/berkeley</loc><lastmod>2026-04-01</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/players/refereefox</loc><lastmod>2026-05-24</lastmod>"));
 });


### PR DESCRIPTION
## Summary
- Build the new `/playing` static route from `ks-content/site/playing`.
- Add `/playing` to route/navigation contracts, sitemap generation, smoke/SEO/structured-data defaults, and release docs.
- Update footer fallback ordering so the Game column starts with `Play online`, `Playing here`, and `Leaderboard`.
- Bump `ks-home` to `1.2.27`.

## Rationale
The platform play guide needs a public static route and footer placement on `kriegspiel.org`. The static build should also keep `/playing` in normal validation so it is checked during future releases.

## Companion PRs
- Requires content entry from https://github.com/Kriegspiel/ks-content/pull/136 before the default static build can pass without `KS_CONTENT_PATH`.
- App footer mapping is in the companion `ks-web-app` PR.

## Tests
Validated at commit `f450bc1` with `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-platform-game-guide`:
- `npm run content:schema:check` — PASS
- `npm run routes:validate` — PASS
- `npm test` — PASS (59 tests)
- `npm run build` — PASS
- `npm run test:smoke` — PASS
- `npm run seo:validate` — PASS
- `npm run structured-data:check` — PASS
- `npm run sitemap:generate -- --check` — PASS
- `npm run lint` — PASS

## Deployment Notes
Merge/deploy after the `ks-content` PR is merged or at the same rollout point. This is a user-visible static-site change and should refresh `kriegspiel.org`; no backend restart is required.
