### PR TITLE
[codex] add levels static route

### DIFF
--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -13,6 +13,10 @@
       "href": "/rules"
     },
     {
+      "label": "Levels",
+      "href": "/levels"
+    },
+    {
       "label": "Play",
       "href": "https://app.kriegspiel.org/"
     }

--- a/contracts/routes.json
+++ b/contracts/routes.json
@@ -6,6 +6,7 @@
     "/changelog",
     "/rules",
     "/playing",
+    "/levels",
     "/privacy",
     "/terms"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.29",
+      "version": "1.2.30",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -16,6 +16,7 @@ const privacyEntry = loadSingletonEntry(contentRoot, 'site', 'privacy');
 const termsEntry = loadSingletonEntry(contentRoot, 'site', 'terms');
 const aboutEntry = loadSingletonEntry(contentRoot, 'site', 'about');
 const playingEntry = loadSingletonEntry(contentRoot, 'site', 'playing');
+const levelsEntry = loadSingletonEntry(contentRoot, 'site', 'levels');
 const footerEntry = loadSingletonEntry(contentRoot, 'site', 'footer');
 const CHESS_PIECE_ASSETS = [
   'LICENSE.md',
@@ -98,6 +99,7 @@ writePage(path.join(dist, 'privacy/index.html'), renderSiteMarkdownPage(privacyE
 writePage(path.join(dist, 'terms/index.html'), renderSiteMarkdownPage(termsEntry, footerEntry));
 writePage(path.join(dist, 'about/index.html'), renderSiteMarkdownPage(aboutEntry, footerEntry));
 writePage(path.join(dist, 'playing/index.html'), renderSiteMarkdownPage(playingEntry, footerEntry));
+writePage(path.join(dist, 'levels/index.html'), renderSiteMarkdownPage(levelsEntry, footerEntry));
 writePage(path.join(dist, '404.html'), renderSimplePage('Not Found', footerEntry));
 
 for (const entry of blogEntries) writePage(path.join(dist, 'blog', entry.metadata.slug, 'index.html'), renderBlogDetail(entry, footerEntry));
@@ -108,7 +110,7 @@ writePage(path.join(dist, 'rules/wild-16/index.html'), renderRedirectPage({ from
 
 const manifest = {
   generatedAt,
-  sourceHash: createHash('sha256').update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]), site: [[homeEntry.file, homeEntry.metadata.updatedAt], [privacyEntry.file, privacyEntry.metadata.updatedAt], [termsEntry.file, termsEntry.metadata.updatedAt], [aboutEntry.file, aboutEntry.metadata.updatedAt], [playingEntry.file, playingEntry.metadata.updatedAt], [footerEntry.file, footerEntry.metadata.updatedAt]], players: publicData.entries.map((entry) => [entry.username, entry.rating, entry.gamesPlayed]) })).digest('hex'),
+  sourceHash: createHash('sha256').update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]), site: [[homeEntry.file, homeEntry.metadata.updatedAt], [privacyEntry.file, privacyEntry.metadata.updatedAt], [termsEntry.file, termsEntry.metadata.updatedAt], [aboutEntry.file, aboutEntry.metadata.updatedAt], [playingEntry.file, playingEntry.metadata.updatedAt], [levelsEntry.file, levelsEntry.metadata.updatedAt], [footerEntry.file, footerEntry.metadata.updatedAt]], players: publicData.entries.map((entry) => [entry.username, entry.rating, entry.gamesPlayed]) })).digest('hex'),
   blogRoutes: blogEntries.map((entry) => `/blog/${entry.metadata.slug}`),
   changelogRoutes: changelogEntries.map((entry) => `/changelog/${entry.metadata.slug}`),
   ruleRoutes: ['/rules', '/rules/comparison', ...rulesEntries.map((entry) => `/rules/${entry.metadata.slug}`)],
@@ -123,7 +125,7 @@ writePage(path.join(dist, 'sitemap.xml'), renderSitemap(buildSitemapRoutes({
   blogEntries,
   changelogEntries,
   rulesEntries,
-  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry },
+  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry, levels: levelsEntry },
   playerRoutes: manifest.playerRoutes,
   generatedAt,
 })));

--- a/scripts/deploy/smoke.sh
+++ b/scripts/deploy/smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-}"
-ROUTES="/,/leaderboard,/blog,/changelog,/rules,/playing"
+ROUTES="/,/leaderboard,/blog,/changelog,/rules,/playing,/levels"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/seo-validate.mjs
+++ b/scripts/seo-validate.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/playing").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/playing,/levels").split(",");
 
 const requiredChecks = [
   { name: "<title>", re: /<title>[^<]+<\/title>/i },

--- a/scripts/sitemap-generate.mjs
+++ b/scripts/sitemap-generate.mjs
@@ -13,13 +13,14 @@ const privacyEntry = loadSingletonEntry(contentRoot, "site", "privacy");
 const termsEntry = loadSingletonEntry(contentRoot, "site", "terms");
 const aboutEntry = loadSingletonEntry(contentRoot, "site", "about");
 const playingEntry = loadSingletonEntry(contentRoot, "site", "playing");
+const levelsEntry = loadSingletonEntry(contentRoot, "site", "levels");
 const manifestPath = path.join(process.cwd(), "dist/.regen-manifest.json");
 const manifest = fs.existsSync(manifestPath) ? JSON.parse(fs.readFileSync(manifestPath, "utf8")) : {};
 const xml = renderSitemap(buildSitemapRoutes({
   blogEntries,
   changelogEntries,
   rulesEntries,
-  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry },
+  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry, levels: levelsEntry },
   playerRoutes: Array.isArray(manifest.playerRoutes) ? manifest.playerRoutes : [],
   generatedAt: manifest.generatedAt || new Date().toISOString(),
 }));

--- a/scripts/structured-data-check.mjs
+++ b/scripts/structured-data-check.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const targets = ["/", "/blog", "/changelog", "/rules", "/playing"];
+const targets = ["/", "/blog", "/changelog", "/rules", "/playing", "/levels"];
 let failures = 0;
 for (const route of targets) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;

--- a/scripts/test-smoke-routes.mjs
+++ b/scripts/test-smoke-routes.mjs
@@ -6,7 +6,7 @@ import { execSync } from "node:child_process";
 execSync("node scripts/build.mjs", { stdio: "pipe" });
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/rules,/playing").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/rules,/playing,/levels").split(",");
 for (const route of routes) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;
   assert.ok(fs.existsSync(path.join(process.cwd(), "dist", rel)), `missing route ${route}`);

--- a/src/site-feeds.mjs
+++ b/src/site-feeds.mjs
@@ -56,6 +56,7 @@ export function buildSitemapRoutes({
     { path: "/terms", lastmod: siteEntries.terms?.metadata?.updatedAt },
     { path: "/about", lastmod: siteEntries.about?.metadata?.updatedAt },
     { path: "/playing", lastmod: siteEntries.playing?.metadata?.updatedAt },
+    { path: "/levels", lastmod: siteEntries.levels?.metadata?.updatedAt },
     ...blogEntries.map((entry) => ({ path: `/blog/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),
     ...changelogEntries.map((entry) => ({ path: `/changelog/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),
     ...rulesEntries.map((entry) => ({ path: `/rules/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -6,7 +6,7 @@ import { execSync } from 'node:child_process';
 
 test('build emits required public pages', () => {
   execSync('node scripts/build.mjs', { stdio: 'pipe' });
-  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'playing/index.html', 'privacy/index.html', 'terms/index.html']) {
+  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'playing/index.html', 'levels/index.html', 'privacy/index.html', 'terms/index.html']) {
     assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', routeFile)), `missing ${routeFile}`);
   }
   assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', 'social-card-20260511.png')), 'missing social-card-20260511.png');
@@ -23,5 +23,6 @@ test('build emits required public pages', () => {
   assert.ok(atom.includes('<feed xmlns="http://www.w3.org/2005/Atom"'));
   assert.ok(sitemap.includes('https://kriegspiel.org/rules/berkeley'));
   assert.ok(sitemap.includes('https://kriegspiel.org/playing'));
+  assert.ok(sitemap.includes('https://kriegspiel.org/levels'));
   assert.ok(sitemap.includes('<lastmod>'));
 });

--- a/tests/routes-contract.test.mjs
+++ b/tests/routes-contract.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 const routes = JSON.parse(fs.readFileSync(new URL("../contracts/routes.json", import.meta.url), "utf8"));
 
 test("required route set includes public + trust pages", () => {
-  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/playing", "/privacy", "/terms"]) {
+  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/playing", "/levels", "/privacy", "/terms"]) {
     assert.ok(routes.requiredStaticRoutes.includes(route));
   }
 });

--- a/tests/site-feeds.test.mjs
+++ b/tests/site-feeds.test.mjs
@@ -73,6 +73,7 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
       terms: { metadata: { updatedAt: "2026-03-29" } },
       about: { metadata: { updatedAt: "2026-03-30" } },
       playing: { metadata: { updatedAt: "2026-07-05" } },
+      levels: { metadata: { updatedAt: "2026-07-05" } },
     },
     playerRoutes: ["/players/refereefox", "/blog/research-map"],
     generatedAt: "2026-05-24T00:00:00.000Z",
@@ -83,6 +84,7 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
   const sitemap = renderSitemap(routes);
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/</loc><lastmod>2026-03-27</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/playing</loc><lastmod>2026-07-05</lastmod>"));
+  assert.ok(sitemap.includes("<loc>https://kriegspiel.org/levels</loc><lastmod>2026-07-05</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/rules/berkeley</loc><lastmod>2026-04-01</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/players/refereefox</loc><lastmod>2026-05-24</lastmod>"));
 });


### PR DESCRIPTION
## Summary
- Generate the new `/levels` static page from the `ks-content` site entry.
- Add `/levels` to route contracts, sitemap generation, SEO/structured-data/smoke route checks, and tests.
- Bump `ks-home` to `1.2.30` for the user-visible static-site route.

## Rationale
The levels page needs a first-class static route at `kriegspiel.org/levels` while keeping the footer unchanged for now.

## Content Dependency
- Depends on Kriegspiel/ks-content#138 for `site/levels/README.md`.

## Tests
Run with `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels`:
- `npm run content:schema:check`
- `npm run content:source-contract:check`
- `npm run routes:validate`
- `npm run build`
- `npm run test`
- `npm run lint`
- `npm run seo:validate`
- `npm run structured-data:check`
- `npm run test:smoke`

## Deployment Notes
After merge, fast-forward deployed `ks-content` first, then `ks-home`, rebuild the static site, and verify `https://kriegspiel.org/levels`. No footer link is added in this change.
