### PR TITLE
[codex] bump ks-home to 1.3.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.0
+
+- **Static Site Version**: promote the public site package to `1.3.0` after
+  the playing guide and levels page updates.
+
 ## ks-home v. 1.2.31
 
 - **Levels**: style the public levels page as a tier feature matrix with

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.2.31",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.2.31",
+      "version": "1.3.0",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.2.31",
+  "version": "1.3.0",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `ks-home` package and lockfile from `1.2.31` to `1.3.0`.
- Add a `ks-home v. 1.3.0` release-note entry.

## Rationale
This promotes the public static-site package to `1.3.0` after the recent playing guide and levels page updates.

## Validation
- `git diff --check` — PASS
- `npm run content:schema:check` with `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-current-validation` — PASS (24 documents)
- `npm run routes:validate` — PASS
- `npm test` — PASS (61 tests)
- `npm run build` — PASS
- `npm run test:smoke` — PASS (5 routes)
- `npm run seo:validate` — PASS (7 routes)
- `npm run structured-data:check` — PASS
- `npm run sitemap:generate -- --check` — PASS
- `npm run lint` — PASS (37 files)
- Verified generated assets use `?v=1.3.0`.

## Deployment Notes
Static-site version bump only. Deploy with `ks-deploy home` after merge so generated asset query strings move to `1.3.0`.
