### PR TITLE
Simplify homepage games tile

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.9
+
+- **Homepage**: simplify the games-played tile to the current rounded total
+  and a single “Total games played as of now.” line.
+
 ## ks-home v. 1.3.8
 
 - **Homepage**: add a rounded all-time games-played tile and a Saturday

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -124,7 +124,7 @@ function formatThousandsPlus(value, fallbackValue = 21000) {
   const fallback = Number(fallbackValue);
   const selected = Number.isFinite(number) && number >= 1000 ? number : fallback;
   const safeValue = Number.isFinite(selected) && selected >= 1000 ? selected : 21000;
-  return `${Math.floor(safeValue / 1000)}k+`;
+  return `${Math.floor(safeValue / 1000)}K plus`;
 }
 function formatDateLabel(value) { if (!value) return 'Unknown'; const parsed = new Date(value); return Number.isNaN(parsed.getTime()) ? esc(value) : esc(parsed.toLocaleDateString()); }
 function dateTimeAttribute(value) { const parsed = new Date(value); return Number.isNaN(parsed.getTime()) ? String(value || '') : parsed.toISOString().slice(0, 10); }
@@ -193,14 +193,15 @@ export function renderShell({ title, description, main, activeNav = '/', canonic
 
 function renderHomeCommunityTiles(content = {}, lobbyStats = null) {
   const gamesLabel = formatThousandsPlus(lobbyStats?.completed_total, content.communityGamesFallbackValue);
-  const gamesTitle = content.communityGamesTitle || 'Total games played';
-  const gamesBody = content.communityGamesBody || 'Rounded down to the nearest thousand and refreshed weekly.';
+  const gamesTitle = content.communityGamesTitle || 'Total games played as of now.';
+  const gamesBody = content.communityGamesBody || '';
+  const gamesBodyHtml = gamesBody ? `<span>${esc(gamesBody)}</span>` : '';
   const inviteTitle = content.communityInviteTitle || 'Saturday human games';
   const inviteBody = content.communityInviteBody || 'Come play human vs human every Saturday at 15:00 UTC.';
   const inviteTimes = content.communityInviteTimes || 'China 23:00; Central Europe 17:00 summer / 16:00 winter; UK 16:00 summer / 15:00 winter; U.S. Pacific 08:00 summer / 07:00 winter.';
   const inviteCtaLabel = content.communityInviteCtaLabel || 'Play human games';
   const inviteCtaHref = content.communityInviteCtaHref || content.heroPrimaryCtaHref || 'https://app.kriegspiel.org/';
-  return `<div class="feature-grid feature-grid--three home-list home-list--compact home-rendezvous-grid" aria-label="Community play"><div class="surface-card home-list__card home-stat-card"><strong class="home-stat-card__value">${esc(gamesLabel)} games played</strong><span>${esc(gamesTitle)}</span><span>${esc(gamesBody)}</span></div><div class="surface-card home-list__card home-rendezvous-card"><strong>${esc(inviteTitle)}</strong><span>${esc(inviteBody)}</span><span class="home-rendezvous-card__times">${esc(inviteTimes)}</span><div class="home-rendezvous-card__actions"><a class="button-link button-link--primary" href="${esc(inviteCtaHref)}">${esc(inviteCtaLabel)}</a></div></div></div>`;
+  return `<div class="feature-grid feature-grid--three home-list home-list--compact home-rendezvous-grid" aria-label="Community play"><div class="surface-card home-list__card home-stat-card"><strong class="home-stat-card__value">${esc(gamesLabel)} games played</strong><span>${esc(gamesTitle)}</span>${gamesBodyHtml}</div><div class="surface-card home-list__card home-rendezvous-card"><strong>${esc(inviteTitle)}</strong><span>${esc(inviteBody)}</span><span class="home-rendezvous-card__times">${esc(inviteTimes)}</span><div class="home-rendezvous-card__actions"><a class="button-link button-link--primary" href="${esc(inviteCtaHref)}">${esc(inviteCtaLabel)}</a></div></div></div>`;
 }
 
 export function renderHomePage({ rulesCount = 0, blogCount = 0, homeContent, footerEntry, lobbyStats = null }) {

--- a/tests/home-leaderboard-pages.test.mjs
+++ b/tests/home-leaderboard-pages.test.mjs
@@ -25,9 +25,8 @@ const homeContent = {
   flowStep2Body: "The referee handles what each player is allowed to know.",
   flowStep3Title: "Stay in the mystery",
   flowStep3Body: "Every turn keeps the tension that makes Kriegspiel fun.",
-  communityGamesTitle: "Total games played",
+  communityGamesTitle: "Total games played as of now.",
   communityGamesFallbackValue: "27000",
-  communityGamesBody: "Rounded down to the nearest thousand and refreshed weekly.",
   communityInviteTitle: "Saturday human games",
   communityInviteBody: "Join the weekly human-vs-human meetup at 15:00 UTC.",
   communityInviteTimes: "China 23:00; Central Europe 17:00 summer / 16:00 winter; UK 16:00 summer / 15:00 winter; U.S. Pacific 08:00 summer / 07:00 winter.",
@@ -77,9 +76,9 @@ test("home page keeps a simplified play-first layout with CTA telemetry", () => 
   assert.ok(html.includes('class="hero-card__eyebrow" hidden'));
   assert.ok(!html.includes('class="hero-card__eyebrow">Kriegspiel.org<'));
   assert.ok(!html.includes('3 public updates are already live.'));
-  assert.ok(html.includes('21k+ games played'));
-  assert.ok(html.includes('Total games played'));
-  assert.ok(html.includes('Rounded down to the nearest thousand and refreshed weekly.'));
+  assert.ok(html.includes('21K plus games played'));
+  assert.ok(html.includes('Total games played as of now.'));
+  assert.ok(!html.includes('Rounded down to the nearest thousand and refreshed weekly.'));
   assert.ok(html.includes('Saturday human games'));
   assert.ok(html.includes('Join the weekly human-vs-human meetup at 15:00 UTC.'));
   assert.ok(html.includes('China 23:00; Central Europe 17:00 summer / 16:00 winter; UK 16:00 summer / 15:00 winter; U.S. Pacific 08:00 summer / 07:00 winter.'));


### PR DESCRIPTION
Summary
- Format the homepage games-played count as `K plus` instead of `k+`.
- Make the games tile body optional and remove the weekly rounding explainer.
- Bump `ks-home` to 1.3.9 and update the homepage rendering test.

Rationale
- The tile should read as a simple current total: `27K plus games played` and `Total games played as of now.`

Tests
- `node --test tests/home-leaderboard-pages.test.mjs tests/pages-branches.test.mjs`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-simplify-games-tile node scripts/check-content-schema.mjs`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-simplify-games-tile KS_API_BASE=https://api.kriegspiel.org npm run build`
- `npm test`

Deployment notes
- Deploy with `ks-deploy home` after the paired content PR merges; this refreshes content, rebuilds the static site, and restarts only `ks-home`.