### PR TITLE
Bump home version for LLM bot tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump ks-home version to 1.3.11 for the public levels refresh

## Rationale
The visible /levels content change needs a ks-home refresh and version trail when deployed.

## Tests
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-llm-bot-tiers npm run build
- npm run test -- tests/content-utils.test.mjs tests/trust-rules-pages.test.mjs tests/build-smoke.test.mjs
- rendered dist/levels/index.html contains Available LLM bots, Qwen3.6 Flash, and GPT-5.5 Pro

## Deployment notes
Deploy after the ks-content PR is merged and the deployed content checkout has the new levels entry.