### PR TITLE
Add UTC time to meetup heading

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.14
+
+- **Homepage**: include the canonical UTC meetup time in the Saturday games
+  meetup heading.
+
 ## ks-home v. 1.3.13
 
 - **Homepage**: add a structural line break between the games count and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -141,6 +141,10 @@ function parseUtcClock(value = '15:00') {
     minute: Number.isInteger(minute) && minute >= 0 && minute <= 59 ? minute : 0,
   };
 }
+function formatUtcClockLabel(value = '15:00') {
+  const { hour, minute } = parseUtcClock(value);
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
 function nextWeeklyMeetupUtcDate(referenceValue, utcClock = '15:00') {
   const reference = new Date(referenceValue || Date.now());
   const safeReference = Number.isNaN(reference.getTime()) ? new Date() : reference;
@@ -261,7 +265,8 @@ function renderHomeCommunityTiles(content = {}, lobbyStats = null, generatedAt =
   const gamesTitle = content.communityGamesTitle || 'Total games played as of now.';
   const gamesBody = content.communityGamesBody || '';
   const gamesBodyHtml = gamesBody ? `<span>${esc(gamesBody)}</span>` : '';
-  const inviteTitle = content.communityInviteTitle || 'Saturday games meetup';
+  const inviteTitleBase = content.communityInviteTitle || 'Saturday games meetup';
+  const inviteTitle = /\bUTC\b/.test(inviteTitleBase) ? inviteTitleBase : `${inviteTitleBase}: ${formatUtcClockLabel(content.communityInviteUtcTime)} UTC`;
   const inviteBody = content.communityInviteBody || '';
   const inviteBodyHtml = inviteBody ? `<span>${esc(inviteBody)}</span>` : '';
   const inviteTimes = content.communityInviteTimes || formatCurrentMeetupTimes(content.communityInviteUtcTime, generatedAt);

--- a/tests/home-leaderboard-pages.test.mjs
+++ b/tests/home-leaderboard-pages.test.mjs
@@ -85,7 +85,7 @@ test("home page keeps a simplified play-first layout with CTA telemetry", () => 
   assert.ok(!html.includes('21K plus games played'));
   assert.ok(html.includes('Total games played as of now.'));
   assert.ok(!html.includes('Rounded down to the nearest thousand and refreshed weekly.'));
-  assert.ok(html.includes('Saturday games meetup'));
+  assert.ok(html.includes('Saturday games meetup: 15:00 UTC'));
   assert.ok(!html.includes('Join the weekly human-vs-human meetup at 15:00 UTC.'));
   assert.ok(html.includes('China 23:00 CST; Central Europe 17:00 CEST; UK 16:00 BST; U.S. Pacific 08:00 PDT.'));
   assert.ok(!html.includes('summer /'));


### PR DESCRIPTION
Summary
- Render the meetup heading as `Saturday games meetup: 15:00 UTC` using the configured `communityInviteUtcTime`.
- Keep the local timezone conversion line below the heading.
- Bump `ks-home` to 1.3.14 and update the homepage rendering test.

Rationale
- The meetup tile should show the canonical UTC start time directly in the heading.

Tests
- `node --test tests/home-leaderboard-pages.test.mjs tests/pages-branches.test.mjs`
- `KS_API_BASE=https://api.kriegspiel.org npm run build`
- `npm test`

Deployment notes
- Deploy with `ks-deploy home`; this rebuilds the static site and restarts only `ks-home`.