### PR TITLE
Bump home version after levels row update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump ks-home version to 1.3.15 for the levels page refresh

## Rationale
The public levels page changed, so the static site gets a version trail for deployment.

## Tests
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-llm-play-row npm run build
- npm run test -- tests/content-utils.test.mjs tests/trust-rules-pages.test.mjs tests/build-smoke.test.mjs
- rendered dist/levels/index.html checked to ensure Play language-model bots is absent and Available LLM bots remains present

## Deployment notes
Deploy after the ks-content PR is merged.