### PR TITLE
Bump home version for levels bot tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.15",
+      "version": "1.3.16",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `ks-home` from `1.3.15` to `1.3.16` for the user-visible `/levels` refresh

## Rationale
The static site build is changing public copy and links on `kriegspiel.org/levels`, so the home package version should move with the deployed site.

## Tests
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run build`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run test -- tests/content-utils.test.mjs tests/trust-rules-pages.test.mjs tests/build-smoke.test.mjs`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run routes:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run seo:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-play-tier-bot-links npm run structured-data:check`

## Deployment Notes
Deploy with `ks-deploy home` after the content and home PRs are merged.
