### PR TITLE
Merge identical tier matrix cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.17",
+      "version": "1.3.18",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/content-utils.mjs
+++ b/src/content-utils.mjs
@@ -356,15 +356,27 @@ function renderTierFeatureTable(headerCells, rows) {
     return `<th scope="col"${tierColumnClass}><span class="tier-feature-table__heading"><span class="tier-feature-table__tier-label"><span class="tier-feature-table__tier-prefix">Tier</span><span class="${tierNumberClass}">${inlineMarkdown(tierCode)}</span></span><span class="tier-feature-table__name">${inlineMarkdown(tierName)}</span>${detailHtml}</span></th>`;
   }).join("")}</tr></thead>`;
   const bodyRows = rows
-    .map((cells) => `<tr>${normalize(cells).map((cell, index) => {
-      if (index === 0) return `<th scope="row">${inlineMarkdown(cell)}</th>`;
-      const cellClasses = tierColumnClasses[index] ? [tierColumnClasses[index]] : [];
-      if (!isCompactAvailabilityCell(cell)) cellClasses.push("tier-feature-table__cell-text");
-      const tierColumnClass = cellClasses.length ? ` class="${cellClasses.join(" ")}"` : "";
-      return `<td${tierColumnClass}>${renderAvailabilityMark(cell)}</td>`;
-    }).join("")}</tr>`)
+    .map((cells) => `<tr>${renderMergedTierFeatureRow(normalize(cells), tierColumnClasses)}</tr>`)
     .join("");
   return `<div class="table-wrap tier-feature-table-wrap"><table class="tier-feature-table">${headHtml}<tbody>${bodyRows}</tbody></table></div>`;
+}
+
+function renderMergedTierFeatureRow(cells, tierColumnClasses) {
+  const renderedCells = [`<th scope="row">${inlineMarkdown(cells[0])}</th>`];
+  let index = 1;
+  while (index < cells.length) {
+    const cell = cells[index];
+    const mergeKey = tierCellMergeKey(cell);
+    let span = 1;
+    while (mergeKey && index + span < cells.length && tierCellMergeKey(cells[index + span]) === mergeKey) span += 1;
+    const cellClasses = tierColumnClasses[index] ? [tierColumnClasses[index]] : [];
+    if (!isCompactAvailabilityCell(cell)) cellClasses.push("tier-feature-table__cell-text");
+    const classAttribute = cellClasses.length ? ` class="${cellClasses.join(" ")}"` : "";
+    const colspanAttribute = span > 1 ? ` colspan="${span}"` : "";
+    renderedCells.push(`<td${classAttribute}${colspanAttribute}>${renderAvailabilityMark(cell)}</td>`);
+    index += span;
+  }
+  return renderedCells.join("");
 }
 
 function tierCodeCssClass(tierCode) {
@@ -381,6 +393,14 @@ function renderAvailabilityMark(cell) {
 function isCompactAvailabilityCell(cell) {
   const value = String(cell || "").trim();
   return /^yes$/i.test(value) || /^no$/i.test(value) || value === "—";
+}
+
+function tierCellMergeKey(cell) {
+  const value = String(cell || "").trim();
+  if (!value) return "";
+  if (/^yes$/i.test(value)) return "yes";
+  if (/^no$/i.test(value)) return "no";
+  return value;
 }
 
 function isMarkdownTableSeparator(line) {

--- a/tests/content-utils.test.mjs
+++ b/tests/content-utils.test.mjs
@@ -222,21 +222,23 @@ test("markdownToHtml renders tier feature tables with availability marks", () =>
     "| Feature | Tier T0 Guest (Free) | Tier T1 Casual (Free) | Tier T2 Club ($10/mo / $100/yr) | Tier T5 Master (Not available yet) | Tier T6 Elite (Not available yet) |",
     "| --- | --- | --- | --- | --- | --- |",
     "| Play language-model bots | No | Yes | Yes | — | — |",
-    "| Play T2 bots | No | No | [OpenAI GPTNano](https://app.kriegspiel.org/user/llm_gptnano) | — | GPT-5.5 Pro |"
+    "| Play T2 bots | No | No | [OpenAI GPTNano](https://app.kriegspiel.org/user/llm_gptnano) | GPT-5.5 Pro | GPT-5.5 Pro |"
   ].join("\n"));
 
   assert.ok(html.includes('<div class="table-wrap tier-feature-table-wrap"><table class="tier-feature-table">'));
   assert.ok(html.includes('<th scope="col" class="tier-feature-table__tier-column tier-feature-table__tier-column--t0"><span class="tier-feature-table__heading"><span class="tier-feature-table__tier-label"><span class="tier-feature-table__tier-prefix">Tier</span><span class="tier-feature-table__number tier-feature-table__number--t0">T0</span></span><span class="tier-feature-table__name">Guest</span>'));
   assert.ok(html.includes('<span class="tier-feature-table__number tier-feature-table__number--t2">T2</span>'));
   assert.ok(html.includes('<th scope="col" class="tier-feature-table__tier-column tier-feature-table__tier-column--t5 tier-feature-table__tier-column--unavailable">'));
-  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t6 tier-feature-table__tier-column--unavailable">—</td>'));
+  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t1" colspan="2"><span class="tier-feature-table__mark tier-feature-table__mark--yes">Yes</span></td>'));
+  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t5 tier-feature-table__tier-column--unavailable" colspan="2">—</td>'));
   assert.ok(html.includes('<span class="tier-feature-table__detail">Free</span>'));
   assert.ok(html.includes('<span class="tier-feature-table__detail">$10/mo / $100/yr</span>'));
   assert.ok(html.includes('<th scope="row">Play language-model bots</th>'));
   assert.ok(html.includes('<span class="tier-feature-table__mark tier-feature-table__mark--no">No</span>'));
   assert.ok(html.includes('<span class="tier-feature-table__mark tier-feature-table__mark--yes">Yes</span>'));
+  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t0" colspan="2"><span class="tier-feature-table__mark tier-feature-table__mark--no">No</span></td>'));
   assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t2 tier-feature-table__cell-text"><a href="https://app.kriegspiel.org/user/llm_gptnano">OpenAI GPTNano</a></td>'));
-  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t6 tier-feature-table__tier-column--unavailable tier-feature-table__cell-text">GPT-5.5 Pro</td>'));
+  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t5 tier-feature-table__tier-column--unavailable tier-feature-table__cell-text" colspan="2">GPT-5.5 Pro</td>'));
 });
 
 test("markdownToHtml renders thematic breaks as horizontal rules", () => {


### PR DESCRIPTION
## Summary
- collapse adjacent identical tier comparison cells into one rendered `colspan` cell
- keep compact Yes/No/— rendering and long model-list cell styling
- bump `ks-home` from `1.3.17` to `1.3.18`

## Rationale
The `/levels` tier matrix repeats inherited bot buckets across later tiers. Rendering adjacent duplicates as merged cells makes the comparison table easier to scan without changing the content source format.

## Tests
- `npm run lint`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-merge-cell-validation npm run build`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-merge-cell-validation npm run test -- tests/content-utils.test.mjs tests/trust-rules-pages.test.mjs tests/build-smoke.test.mjs`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-merge-cell-validation npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-merge-cell-validation npm run routes:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-merge-cell-validation npm run seo:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-merge-cell-validation npm run structured-data:check`

Rendered `/levels` verification:
- T2 bot bucket renders with `colspan="5"`
- T3 bot bucket renders with `colspan="4"`
- T4 bot bucket renders with `colspan="3"`
- T5 bot bucket renders with `colspan="2"`

## Deployment Notes
Deploy with `ks-deploy home` after merge.
