### PR TITLE
Allow provider line breaks in content tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.20",
+      "version": "1.3.21",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/content-utils.mjs
+++ b/src/content-utils.mjs
@@ -646,6 +646,7 @@ function inlineMarkdown(text) {
   };
 
   let rendered = String(text || "")
+    .replace(/<br\s*\/?>/gi, () => placeholder("<br />"))
     .replace(/`([^`]+)`/g, (_, code) => placeholder(`<code>${escapeHtml(code)}</code>`))
     .replace(/\[(.+?)\]\((.+?)\)/g, (_, label, href) => placeholder(`<a href="${escapeAttribute(href)}">${escapeHtml(label)}</a>`));
 

--- a/tests/content-utils.test.mjs
+++ b/tests/content-utils.test.mjs
@@ -222,7 +222,7 @@ test("markdownToHtml renders tier feature tables with availability marks", () =>
     "| Feature | Tier T0 Guest (Free) | Tier T1 Casual (Free) | Tier T2 Club ($10/mo / $100/yr) | Tier T5 Master (Not available yet) | Tier T6 Elite (Not available yet) |",
     "| --- | --- | --- | --- | --- | --- |",
     "| Play language-model bots | No | Yes | Yes | — | — |",
-    "| Play T2 bots | No | No | [OpenAI GPTNano](https://app.kriegspiel.org/user/llm_gptnano) | GPT-5.5 Pro | GPT-5.5 Pro |"
+    "| Play T2 bots | No | No | OpenAI: [GPTNano](https://app.kriegspiel.org/user/llm_gptnano)<br>Anthropic: Claude Haiku 4.5 | GPT-5.5 Pro | GPT-5.5 Pro |"
   ].join("\n"));
 
   assert.ok(html.includes('<div class="table-wrap tier-feature-table-wrap"><table class="tier-feature-table">'));
@@ -240,8 +240,9 @@ test("markdownToHtml renders tier feature tables with availability marks", () =>
   assert.ok(html.includes('<span class="tier-feature-table__mark tier-feature-table__mark--yes">Yes</span>'));
   assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t0"><span class="tier-feature-table__mark tier-feature-table__mark--no">No</span></td>'));
   assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t1"><span class="tier-feature-table__mark tier-feature-table__mark--no">No</span></td>'));
-  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t2 tier-feature-table__cell-text"><a href="https://app.kriegspiel.org/user/llm_gptnano">OpenAI GPTNano</a></td>'));
+  assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t2 tier-feature-table__cell-text">OpenAI: <a href="https://app.kriegspiel.org/user/llm_gptnano">GPTNano</a><br />Anthropic: Claude Haiku 4.5</td>'));
   assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t5 tier-feature-table__tier-column--unavailable tier-feature-table__cell-text" colspan="2">GPT-5.5 Pro</td>'));
+  assert.ok(!html.includes("&lt;br&gt;"));
 });
 
 test("markdownToHtml renders thematic breaks as horizontal rules", () => {


### PR DESCRIPTION
## Summary
- Allow safe inline `<br>`/`<br />` line breaks in content Markdown rendering.
- Add tier-table coverage proving provider line breaks render as real `<br />` inside table cells instead of escaped text.
- Bump `ks-home` to `1.3.21`.

## Rationale
The `/levels` tier matrix should keep each `Play T* bots` bucket in one merged cell, while displaying each provider on a new line as `Provider: models`. The content renderer previously escaped raw `<br>` tags, so this small renderer change is needed before the content update can display correctly.

## Validation
- `npm ci`
- `npm run test` (62 tests)
- `npm run lint`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-provider-lines npm run build`
- Rendered HTML probe confirmed one `Play T* bots` row per tier bucket, provider `<br />` lines inside merged cells, expected colspans, and no escaped `&lt;br&gt;` text.

Verified commit: `7b95187f8144fd60fbec8295068e463477c69e0a`

## Deployment Notes
Deploy `ks-home` before or together with the paired `ks-content` levels update so provider line breaks render correctly on `https://kriegspiel.org/levels`.
