### PR TITLE
[codex] Refresh home for levels pricing rename

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.22
+
+- **Levels**: refresh the public site release for the renamed “Levels and
+  pricing” page.
+
 ## ks-home v. 1.3.14
 
 - **Homepage**: include the canonical UTC meetup time in the Saturday games

--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -13,7 +13,7 @@
       "href": "/rules"
     },
     {
-      "label": "Levels",
+      "label": "Levels and pricing",
       "href": "/levels"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.21",
+      "version": "1.3.22",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -159,7 +159,7 @@ test('site markdown pages keep wrapped tables as scrollable tables on narrow scr
 
 test('site markdown pages include tier feature matrix styles', () => {
   const html = renderSiteMarkdownPage({
-    metadata: { title: 'Kriegspiel Levels', summary: 'Levels page', slug: 'levels' },
+    metadata: { title: 'Levels and pricing', summary: 'Levels page', slug: 'levels' },
     bodyHtml: '<div class="table-wrap tier-feature-table-wrap"><table class="tier-feature-table"></table></div>'
   });
 


### PR DESCRIPTION
## Summary
- Bump `ks-home` from `1.3.21` to `1.3.22` for the public site refresh.
- Rename the `/levels` entry in the navigation contract to `Levels and pricing`.
- Update the levels-page rendering test fixture to use the new title.

## Rationale
The public `/levels` content is being renamed to `Levels and pricing`; this keeps the static-site release and contract aligned with the content change.

## Tests
- `npm run routes:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-pricing npm test`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-levels-pricing npm run build`
- Generated `dist/levels/index.html` contains `<title>Kriegspiel — Levels and pricing</title>` and `<h1>Levels and pricing</h1>`.

## Deployment notes
After both PRs merge, fast-forward the deployed `ks-content` and `ks-home` checkouts, rebuild `ks-home`, restart only the static-site service if needed, and verify `https://kriegspiel.org/levels`.
