### PR TITLE
Align levels pricing split columns

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.28
+
+- **Levels**: align the split pricing matrix header and body columns with a
+  shared column model.
+
 ## ks-home v. 1.3.27
 
 - **Levels**: split the pricing matrix into a frozen header pane and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.27",
+      "version": "1.3.28",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/content-utils.mjs
+++ b/src/content-utils.mjs
@@ -343,6 +343,9 @@ function renderTierFeatureTable(headerCells, rows) {
     if (["t5", "t6"].includes(tierCodeClass)) classes.push("tier-feature-table__tier-column--unavailable");
     return classes.join(" ");
   });
+  const colgroupHtml = `<colgroup><col class="tier-feature-table__feature-col" />${tierColumnClasses.slice(1)
+    .map((classes) => `<col class="${["tier-feature-table__tier-col", classes].filter(Boolean).join(" ")}" />`)
+    .join("")}</colgroup>`;
   const headHtml = `<thead><tr>${normalizedHeaders.map((cell, index) => {
     if (index === 0) return `<th scope="col">${inlineMarkdown(cell)}</th>`;
     const tier = parseTierHeader(cell);
@@ -358,7 +361,7 @@ function renderTierFeatureTable(headerCells, rows) {
   const bodyRows = rows
     .map((cells) => `<tr>${renderMergedTierFeatureRow(normalize(cells), tierColumnClasses)}</tr>`)
     .join("");
-  return `<div class="table-wrap tier-feature-table-wrap" data-tier-feature-table><div class="tier-feature-table__frozen-header" data-tier-feature-table-header><table class="tier-feature-table tier-feature-table--header">${headHtml}</table></div><div class="tier-feature-table__body-scroll" data-tier-feature-table-body tabindex="0" role="region" aria-label="Feature availability by tier"><table class="tier-feature-table tier-feature-table--body"><tbody>${bodyRows}</tbody></table></div></div>`;
+  return `<div class="table-wrap tier-feature-table-wrap" data-tier-feature-table style="--tier-feature-tier-count:${Math.max(1, columnCount - 1)};"><div class="tier-feature-table__frozen-header" data-tier-feature-table-header><table class="tier-feature-table tier-feature-table--header">${colgroupHtml}${headHtml}</table></div><div class="tier-feature-table__body-scroll" data-tier-feature-table-body tabindex="0" role="region" aria-label="Feature availability by tier"><table class="tier-feature-table tier-feature-table--body">${colgroupHtml}<tbody>${bodyRows}</tbody></table></div></div>`;
 }
 
 function renderMergedTierFeatureRow(cells, tierColumnClasses) {

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -499,10 +499,12 @@ function tierFeatureMatrixStyles() {
     `.tier-feature-table__frozen-header{position:sticky;top:var(--tier-feature-sticky-top,0px);z-index:9;overflow:hidden;border-radius:var(--radius) var(--radius) 0 0;background:color-mix(in srgb,var(--surface-alt) 88%,var(--accent-soft));border-bottom:1px solid var(--border);}`,
     `.tier-feature-table__body-scroll{max-height:72vh;overflow:auto;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;border-radius:0 0 var(--radius) var(--radius);}`,
     `.tier-feature-table-wrap .tier-feature-table{width:100%;min-width:86rem;table-layout:fixed;border:0;border-radius:0;border-collapse:separate;border-spacing:0;overflow:visible;}`,
+    `.tier-feature-table__feature-col{width:14rem;}`,
+    `.tier-feature-table__tier-col{width:calc((100% - 14rem) / var(--tier-feature-tier-count,7));}`,
     `.tier-feature-table--header{background:transparent;}`,
     `.tier-feature-table--body{border-top:0;}`,
     `.tier-feature-table--header thead th{vertical-align:top;text-align:center;padding:.9rem .65rem;background:color-mix(in srgb,var(--surface-alt) 88%,var(--accent-soft));box-shadow:0 1px 0 var(--border);}`,
-    `.tier-feature-table--header thead th:first-child{position:sticky;left:0;z-index:2;width:14rem;min-width:14rem;text-align:left;background:color-mix(in srgb,var(--surface-alt) 88%,var(--accent-soft));box-shadow:1px 0 0 var(--border),0 1px 0 var(--border);}`,
+    `.prose-card .tier-feature-table-wrap .tier-feature-table--header thead th:first-child{position:sticky;left:0;z-index:2;width:14rem;min-width:14rem;text-align:left;background:color-mix(in srgb,var(--surface-alt) 88%,var(--accent-soft));box-shadow:1px 0 0 var(--border),0 1px 0 var(--border);}`,
     `.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody th:first-child,.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody td:first-child{width:14rem;min-width:14rem;position:sticky;left:0;z-index:3;background:var(--surface-strong);box-shadow:1px 0 0 var(--border);}`,
     `.tier-feature-table tbody th{font-weight:700;line-height:1.25;}`,
     `.tier-feature-table tbody td{text-align:center;vertical-align:middle;}`,
@@ -533,7 +535,7 @@ function tierFeatureMatrixStyles() {
     `.tier-feature-table__mark{display:inline-flex;align-items:center;justify-content:center;min-width:3.6rem;min-height:1.9rem;padding:.2rem .65rem;border-radius:999px;font-weight:800;line-height:1.2;}`,
     `.tier-feature-table__mark--yes{background:var(--success-bg);color:var(--success);border:1px solid var(--success-border);}`,
     `.tier-feature-table__mark--no{background:var(--danger-bg);color:var(--danger);border:1px solid var(--danger-border);}`,
-    `@media (max-width:700px){.tier-feature-table--header thead th:first-child,.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody th:first-child,.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody td:first-child{width:11rem;min-width:11rem;}.tier-feature-table-wrap .tier-feature-table{min-width:72rem;}}`
+    `@media (max-width:700px){.tier-feature-table__feature-col{width:11rem;}.tier-feature-table__tier-col{width:calc((100% - 11rem) / var(--tier-feature-tier-count,7));}.prose-card .tier-feature-table-wrap .tier-feature-table--header thead th:first-child,.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody th:first-child,.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody td:first-child{width:11rem;min-width:11rem;}.tier-feature-table-wrap .tier-feature-table{min-width:72rem;}}`
   ].join('');
 }
 

--- a/tests/content-utils.test.mjs
+++ b/tests/content-utils.test.mjs
@@ -225,11 +225,14 @@ test("markdownToHtml renders tier feature tables with availability marks", () =>
     "| Play T2 bots | No | No | OpenAI: [GPTNano](https://app.kriegspiel.org/user/llm_gptnano)<br>Anthropic: Claude Haiku 4.5 | GPT-5.5 Pro | GPT-5.5 Pro |"
   ].join("\n"));
 
-  assert.ok(html.includes('<div class="table-wrap tier-feature-table-wrap" data-tier-feature-table>'));
-  assert.ok(html.includes('<div class="tier-feature-table__frozen-header" data-tier-feature-table-header><table class="tier-feature-table tier-feature-table--header">'));
+  assert.ok(html.includes('<div class="table-wrap tier-feature-table-wrap" data-tier-feature-table style="--tier-feature-tier-count:5;">'));
+  assert.ok(html.includes('<colgroup><col class="tier-feature-table__feature-col" /><col class="tier-feature-table__tier-col tier-feature-table__tier-column tier-feature-table__tier-column--t0" />'));
+  assert.ok(html.includes('<col class="tier-feature-table__tier-col tier-feature-table__tier-column tier-feature-table__tier-column--t5 tier-feature-table__tier-column--unavailable" />'));
+  assert.equal((html.match(/<colgroup>/g) || []).length, 2);
+  assert.ok(html.includes('<div class="tier-feature-table__frozen-header" data-tier-feature-table-header><table class="tier-feature-table tier-feature-table--header"><colgroup>'));
   assert.ok(html.includes('<thead><tr><th scope="col">Feature</th>'));
   assert.ok(html.includes('<th scope="col" class="tier-feature-table__tier-column tier-feature-table__tier-column--t0"><span class="tier-feature-table__heading"><span class="tier-feature-table__tier-label"><span class="tier-feature-table__tier-prefix">Tier</span><span class="tier-feature-table__number tier-feature-table__number--t0">T0</span></span><span class="tier-feature-table__name">Guest</span>'));
-  assert.ok(html.includes('</tr></thead></table></div><div class="tier-feature-table__body-scroll" data-tier-feature-table-body tabindex="0" role="region" aria-label="Feature availability by tier"><table class="tier-feature-table tier-feature-table--body"><tbody>'));
+  assert.ok(html.includes('</tr></thead></table></div><div class="tier-feature-table__body-scroll" data-tier-feature-table-body tabindex="0" role="region" aria-label="Feature availability by tier"><table class="tier-feature-table tier-feature-table--body"><colgroup>'));
   assert.ok(html.includes('<span class="tier-feature-table__number tier-feature-table__number--t2">T2</span>'));
   assert.ok(html.includes('<th scope="col" class="tier-feature-table__tier-column tier-feature-table__tier-column--t5 tier-feature-table__tier-column--unavailable">'));
   assert.ok(html.includes('<td class="tier-feature-table__tier-column tier-feature-table__tier-column--t1"><span class="tier-feature-table__mark tier-feature-table__mark--yes">Yes</span></td>'));

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -170,9 +170,12 @@ test('site markdown pages include tier feature matrix styles', () => {
   assert.ok(html.includes('.tier-feature-table__frozen-header{position:sticky;top:var(--tier-feature-sticky-top,0px);z-index:9;overflow:hidden;'));
   assert.ok(html.includes('.tier-feature-table__body-scroll{max-height:72vh;overflow:auto;overscroll-behavior:contain;'));
   assert.ok(html.includes('.tier-feature-table-wrap .tier-feature-table{width:100%;min-width:86rem;table-layout:fixed;border:0;border-radius:0;border-collapse:separate;border-spacing:0;overflow:visible;'));
+  assert.ok(html.includes('.tier-feature-table__feature-col{width:14rem;}'));
+  assert.ok(html.includes('.tier-feature-table__tier-col{width:calc((100% - 14rem) / var(--tier-feature-tier-count,7));}'));
   assert.ok(html.includes('.tier-feature-table--header thead th{vertical-align:top;text-align:center;'));
-  assert.ok(html.includes('.tier-feature-table--header thead th:first-child{position:sticky;left:0;z-index:2;width:14rem;min-width:14rem;'));
+  assert.ok(html.includes('.prose-card .tier-feature-table-wrap .tier-feature-table--header thead th:first-child{position:sticky;left:0;z-index:2;width:14rem;min-width:14rem;'));
   assert.ok(html.includes('.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody th:first-child,.prose-card .tier-feature-table__body-scroll .tier-feature-table tbody td:first-child{width:14rem;min-width:14rem;position:sticky;left:0;z-index:3;'));
+  assert.ok(html.includes('@media (max-width:700px){.tier-feature-table__feature-col{width:11rem;}.tier-feature-table__tier-col{width:calc((100% - 11rem) / var(--tier-feature-tier-count,7));}'));
   assert.ok(html.includes('header.scrollLeft=body.scrollLeft;'));
   assert.ok(html.includes('--tier-feature-sticky-top'));
   assert.ok(html.includes('.tier-feature-table__tier-label{display:grid;justify-items:center;align-content:center;gap:.22rem;width:100%;min-height:3.3rem;}'));


### PR DESCRIPTION
## Summary

- Add matching `colgroup` definitions to the frozen header pane and scrollable body pane for the Levels pricing matrix.
- Set a shared tier-count CSS variable so tier columns use the same width calculation in both panes.
- Increase the header first-column selector specificity so generic prose table rules cannot widen `Feature` independently.
- Bump `ks-home` to `1.3.28` and document the visible alignment fix.

## Rationale

The split header and body tables were computing their first column differently: the header inherited the generic prose-table first-column width while the body used the explicit frozen-column width. Sharing the column model keeps the frozen row and body rows aligned.

## Validation

- `npm ci`
- `npm test` (62 tests passed)
- `npm run build`
- `npm run lint`
- `git diff --check`
- Generated `/levels` HTML checked for exactly two matching `colgroup`s and the shared column-width CSS.

## Deployment Notes

Deploy `ks-home` after merge with `ks-deploy home`, then verify `ks-home.service` health and `https://kriegspiel.org/levels`.
