### PR TITLE
Make levels table use page vertical scroll

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.29
+
+- **Levels**: let the page handle vertical scrolling for the pricing matrix
+  while keeping the tier header frozen.
+
 ## ks-home v. 1.3.28
 
 - **Levels**: align the split pricing matrix header and body columns with a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.28",
+      "version": "1.3.29",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -497,7 +497,7 @@ function tierFeatureMatrixStyles() {
     `@media (min-width:1180px){.content-section--wide{width:min(92vw,96rem);margin-left:50%;transform:translateX(-50%);}.prose-card--wide{padding:1.55rem 1.6rem;}}`,
     `.tier-feature-table-wrap{overflow:visible;border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow-soft);isolation:isolate;position:relative;}`,
     `.tier-feature-table__frozen-header{position:sticky;top:var(--tier-feature-sticky-top,0px);z-index:9;overflow:hidden;border-radius:var(--radius) var(--radius) 0 0;background:color-mix(in srgb,var(--surface-alt) 88%,var(--accent-soft));border-bottom:1px solid var(--border);}`,
-    `.tier-feature-table__body-scroll{max-height:72vh;overflow:auto;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;border-radius:0 0 var(--radius) var(--radius);}`,
+    `.tier-feature-table__body-scroll{overflow-x:auto;overflow-y:visible;overscroll-behavior-x:contain;-webkit-overflow-scrolling:touch;border-radius:0 0 var(--radius) var(--radius);}`,
     `.tier-feature-table-wrap .tier-feature-table{width:100%;min-width:86rem;table-layout:fixed;border:0;border-radius:0;border-collapse:separate;border-spacing:0;overflow:visible;}`,
     `.tier-feature-table__feature-col{width:14rem;}`,
     `.tier-feature-table__tier-col{width:calc((100% - 14rem) / var(--tier-feature-tier-count,7));}`,

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -168,7 +168,7 @@ test('site markdown pages include tier feature matrix styles', () => {
   assert.ok(html.includes('.tier-feature-table-wrap{overflow:visible;border:1px solid var(--border);'));
   assert.ok(html.includes('isolation:isolate;position:relative;'));
   assert.ok(html.includes('.tier-feature-table__frozen-header{position:sticky;top:var(--tier-feature-sticky-top,0px);z-index:9;overflow:hidden;'));
-  assert.ok(html.includes('.tier-feature-table__body-scroll{max-height:72vh;overflow:auto;overscroll-behavior:contain;'));
+  assert.ok(html.includes('.tier-feature-table__body-scroll{overflow-x:auto;overflow-y:visible;overscroll-behavior-x:contain;'));
   assert.ok(html.includes('.tier-feature-table-wrap .tier-feature-table{width:100%;min-width:86rem;table-layout:fixed;border:0;border-radius:0;border-collapse:separate;border-spacing:0;overflow:visible;'));
   assert.ok(html.includes('.tier-feature-table__feature-col{width:14rem;}'));
   assert.ok(html.includes('.tier-feature-table__tier-col{width:calc((100% - 14rem) / var(--tier-feature-tier-count,7));}'));


### PR DESCRIPTION
## Summary

- Removes the `/levels` pricing matrix body's vertical scroll cap so the page handles vertical scrolling.
- Keeps the frozen tier header pane sticky and preserves horizontal scrolling/sync for the wide matrix.
- Bumps `ks-home` to `1.3.29` and adds release notes for the user-visible site behavior change.

## Rationale

The matrix already has a separate frozen header pane and a body pane. The body pane was capped at `72vh` with `overflow:auto`, which forced visitors to scroll inside the table vertically even though the page itself can scroll. Switching the body pane to horizontal-only overflow lets normal document scrolling move through the matrix while the existing sticky header remains pinned under the site nav.

## Tests

- `node --test tests/trust-rules-pages.test.mjs`
- `npm test`
- `npm run build`
- `npm run test:smoke -- --routes=/levels`
- Generated `/levels` HTML check confirmed the new `overflow-x:auto;overflow-y:visible` table body style, no old `max-height:72vh`, and sticky header CSS still present.

Browser screenshot/layout validation was attempted with Playwright, but Chromium could not launch on this host because `libatk-1.0.so.0` is missing.

## Deployment Notes

- Static-site-only `ks-home` change.
- Deploy by rebuilding/refreshing `kriegspiel.org`; no backend or app service restart expected.
