### PR TITLE
Remove public levels page

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.31
+
+- **Site routes**: remove the public `/levels` page from generation,
+  navigation, sitemap, and smoke route coverage.
+
 ## ks-home v. 1.3.30
 
 - **Rules**: soften the Dutch status label to “not playable online yet” and

--- a/contracts/navigation.json
+++ b/contracts/navigation.json
@@ -13,10 +13,6 @@
       "href": "/rules"
     },
     {
-      "label": "Levels and pricing",
-      "href": "/levels"
-    },
-    {
       "label": "Play",
       "href": "https://app.kriegspiel.org/"
     }

--- a/contracts/routes.json
+++ b/contracts/routes.json
@@ -6,7 +6,6 @@
     "/changelog",
     "/rules",
     "/playing",
-    "/levels",
     "/privacy",
     "/terms"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.30",
+  "version": "1.3.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.30",
+      "version": "1.3.31",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.30",
+  "version": "1.3.31",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -16,7 +16,6 @@ const privacyEntry = loadSingletonEntry(contentRoot, 'site', 'privacy');
 const termsEntry = loadSingletonEntry(contentRoot, 'site', 'terms');
 const aboutEntry = loadSingletonEntry(contentRoot, 'site', 'about');
 const playingEntry = loadSingletonEntry(contentRoot, 'site', 'playing');
-const levelsEntry = loadSingletonEntry(contentRoot, 'site', 'levels');
 const footerEntry = loadSingletonEntry(contentRoot, 'site', 'footer');
 const CHESS_PIECE_ASSETS = [
   'LICENSE.md',
@@ -100,7 +99,6 @@ writePage(path.join(dist, 'privacy/index.html'), renderSiteMarkdownPage(privacyE
 writePage(path.join(dist, 'terms/index.html'), renderSiteMarkdownPage(termsEntry, footerEntry));
 writePage(path.join(dist, 'about/index.html'), renderSiteMarkdownPage(aboutEntry, footerEntry));
 writePage(path.join(dist, 'playing/index.html'), renderSiteMarkdownPage(playingEntry, footerEntry));
-writePage(path.join(dist, 'levels/index.html'), renderSiteMarkdownPage(levelsEntry, footerEntry));
 writePage(path.join(dist, '404.html'), renderSimplePage('Not Found', footerEntry));
 
 for (const entry of blogEntries) writePage(path.join(dist, 'blog', entry.metadata.slug, 'index.html'), renderBlogDetail(entry, footerEntry));
@@ -111,7 +109,7 @@ writePage(path.join(dist, 'rules/wild-16/index.html'), renderRedirectPage({ from
 
 const manifest = {
   generatedAt,
-  sourceHash: createHash('sha256').update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]), site: [[homeEntry.file, homeEntry.metadata.updatedAt], [privacyEntry.file, privacyEntry.metadata.updatedAt], [termsEntry.file, termsEntry.metadata.updatedAt], [aboutEntry.file, aboutEntry.metadata.updatedAt], [playingEntry.file, playingEntry.metadata.updatedAt], [levelsEntry.file, levelsEntry.metadata.updatedAt], [footerEntry.file, footerEntry.metadata.updatedAt]], players: publicData.entries.map((entry) => [entry.username, entry.rating, entry.gamesPlayed]), lobbyStats: lobbyStats?.completed_total ?? null })).digest('hex'),
+  sourceHash: createHash('sha256').update(JSON.stringify({ blog: blogEntries.map((e) => [e.file, e.metadata.updatedAt]), changelog: changelogEntries.map((e) => [e.file, e.metadata.updatedAt]), rules: rulesEntries.map((e) => [e.file, e.metadata.updatedAt]), site: [[homeEntry.file, homeEntry.metadata.updatedAt], [privacyEntry.file, privacyEntry.metadata.updatedAt], [termsEntry.file, termsEntry.metadata.updatedAt], [aboutEntry.file, aboutEntry.metadata.updatedAt], [playingEntry.file, playingEntry.metadata.updatedAt], [footerEntry.file, footerEntry.metadata.updatedAt]], players: publicData.entries.map((entry) => [entry.username, entry.rating, entry.gamesPlayed]), lobbyStats: lobbyStats?.completed_total ?? null })).digest('hex'),
   blogRoutes: blogEntries.map((entry) => `/blog/${entry.metadata.slug}`),
   changelogRoutes: changelogEntries.map((entry) => `/changelog/${entry.metadata.slug}`),
   ruleRoutes: ['/rules', '/rules/comparison', ...rulesEntries.map((entry) => `/rules/${entry.metadata.slug}`)],
@@ -126,7 +124,7 @@ writePage(path.join(dist, 'sitemap.xml'), renderSitemap(buildSitemapRoutes({
   blogEntries,
   changelogEntries,
   rulesEntries,
-  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry, levels: levelsEntry },
+  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry },
   playerRoutes: manifest.playerRoutes,
   generatedAt,
 })));

--- a/scripts/deploy/smoke.sh
+++ b/scripts/deploy/smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-}"
-ROUTES="/,/leaderboard,/blog,/changelog,/rules,/playing,/levels"
+ROUTES="/,/leaderboard,/blog,/changelog,/rules,/playing"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/seo-validate.mjs
+++ b/scripts/seo-validate.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/playing,/levels").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/playing").split(",");
 
 const requiredChecks = [
   { name: "<title>", re: /<title>[^<]+<\/title>/i },

--- a/scripts/sitemap-generate.mjs
+++ b/scripts/sitemap-generate.mjs
@@ -13,14 +13,13 @@ const privacyEntry = loadSingletonEntry(contentRoot, "site", "privacy");
 const termsEntry = loadSingletonEntry(contentRoot, "site", "terms");
 const aboutEntry = loadSingletonEntry(contentRoot, "site", "about");
 const playingEntry = loadSingletonEntry(contentRoot, "site", "playing");
-const levelsEntry = loadSingletonEntry(contentRoot, "site", "levels");
 const manifestPath = path.join(process.cwd(), "dist/.regen-manifest.json");
 const manifest = fs.existsSync(manifestPath) ? JSON.parse(fs.readFileSync(manifestPath, "utf8")) : {};
 const xml = renderSitemap(buildSitemapRoutes({
   blogEntries,
   changelogEntries,
   rulesEntries,
-  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry, levels: levelsEntry },
+  siteEntries: { home: homeEntry, privacy: privacyEntry, terms: termsEntry, about: aboutEntry, playing: playingEntry },
   playerRoutes: Array.isArray(manifest.playerRoutes) ? manifest.playerRoutes : [],
   generatedAt: manifest.generatedAt || new Date().toISOString(),
 }));

--- a/scripts/structured-data-check.mjs
+++ b/scripts/structured-data-check.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const targets = ["/", "/blog", "/changelog", "/rules", "/playing", "/levels"];
+const targets = ["/", "/blog", "/changelog", "/rules", "/playing"];
 let failures = 0;
 for (const route of targets) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;

--- a/scripts/test-smoke-routes.mjs
+++ b/scripts/test-smoke-routes.mjs
@@ -6,7 +6,7 @@ import { execSync } from "node:child_process";
 execSync("node scripts/build.mjs", { stdio: "pipe" });
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/rules,/playing,/levels").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/rules,/playing").split(",");
 for (const route of routes) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;
   assert.ok(fs.existsSync(path.join(process.cwd(), "dist", rel)), `missing route ${route}`);

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -474,15 +474,12 @@ export function renderRedirectPage({ fromPath, toPath, title = 'Redirecting…',
 
 export function renderSiteMarkdownPage(entry, footerEntry = null) {
   const versionStamp = entry.metadata.slug === 'about' ? `<p class="page-meta-stamp">Version ${esc(PACKAGE_VERSION)}</p>` : '';
-  const isLevelsPage = entry.metadata.slug === 'levels';
-  const sectionClass = isLevelsPage ? 'content-section content-section--wide' : 'content-section';
-  const articleClass = isLevelsPage ? 'prose-card prose-card--wide' : 'prose-card';
   return renderShell({
     footerEntry,
     title: `Kriegspiel — ${entry.metadata.title}`,
     description: entry.metadata.summary,
     canonicalPath: `/${entry.metadata.slug}`,
-    main: `<section class="${sectionClass}"><article class="${articleClass}"><h1>${esc(entry.metadata.title)}</h1>${entry.bodyHtml}${versionStamp}</article></section>`
+    main: `<section class="content-section"><article class="prose-card"><h1>${esc(entry.metadata.title)}</h1>${entry.bodyHtml}${versionStamp}</article></section>`
   });
 }
 

--- a/src/site-feeds.mjs
+++ b/src/site-feeds.mjs
@@ -56,7 +56,6 @@ export function buildSitemapRoutes({
     { path: "/terms", lastmod: siteEntries.terms?.metadata?.updatedAt },
     { path: "/about", lastmod: siteEntries.about?.metadata?.updatedAt },
     { path: "/playing", lastmod: siteEntries.playing?.metadata?.updatedAt },
-    { path: "/levels", lastmod: siteEntries.levels?.metadata?.updatedAt },
     ...blogEntries.map((entry) => ({ path: `/blog/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),
     ...changelogEntries.map((entry) => ({ path: `/changelog/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),
     ...rulesEntries.map((entry) => ({ path: `/rules/${entry.metadata.slug}`, lastmod: entry.metadata.updatedAt || entry.metadata.publishedAt })),

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -6,9 +6,10 @@ import { execSync } from 'node:child_process';
 
 test('build emits required public pages', () => {
   execSync('node scripts/build.mjs', { stdio: 'pipe' });
-  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'playing/index.html', 'levels/index.html', 'privacy/index.html', 'terms/index.html']) {
+  for (const routeFile of ['index.html', 'leaderboard/index.html', 'blog/index.html', 'blog/archive/index.html', 'blog/welcome/index.html', 'changelog/index.html', 'changelog/2026-03-27-slice-940-trust-discoverability/index.html', 'rules/index.html', 'rules/berkeley/index.html', 'rules/wild16/index.html', 'rules/rand/index.html', 'rules/english/index.html', 'rules/crazykrieg/index.html', 'rules/comparison/index.html', 'playing/index.html', 'privacy/index.html', 'terms/index.html']) {
     assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', routeFile)), `missing ${routeFile}`);
   }
+  assert.ok(!fs.existsSync(path.join(process.cwd(), 'dist', 'levels/index.html')), 'levels page should not be emitted');
   assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', 'social-card-20260511.png')), 'missing social-card-20260511.png');
   assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', 'social/reddit/2026-05-ruleset-default/kriegspiel-ruleset-default-reddit.gif')), 'missing Reddit ruleset GIF');
   assert.ok(fs.existsSync(path.join(process.cwd(), 'dist', 'social/reddit/2026-05-ruleset-default/kriegspiel-ruleset-default-reddit.png')), 'missing Reddit ruleset PNG');
@@ -23,6 +24,6 @@ test('build emits required public pages', () => {
   assert.ok(atom.includes('<feed xmlns="http://www.w3.org/2005/Atom"'));
   assert.ok(sitemap.includes('https://kriegspiel.org/rules/berkeley'));
   assert.ok(sitemap.includes('https://kriegspiel.org/playing'));
-  assert.ok(sitemap.includes('https://kriegspiel.org/levels'));
+  assert.ok(!sitemap.includes('https://kriegspiel.org/levels'));
   assert.ok(sitemap.includes('<lastmod>'));
 });

--- a/tests/routes-contract.test.mjs
+++ b/tests/routes-contract.test.mjs
@@ -5,9 +5,10 @@ import fs from "node:fs";
 const routes = JSON.parse(fs.readFileSync(new URL("../contracts/routes.json", import.meta.url), "utf8"));
 
 test("required route set includes public + trust pages", () => {
-  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/playing", "/levels", "/privacy", "/terms"]) {
+  for (const route of ["/", "/leaderboard", "/blog", "/changelog", "/rules", "/playing", "/privacy", "/terms"]) {
     assert.ok(routes.requiredStaticRoutes.includes(route));
   }
+  assert.ok(!routes.requiredStaticRoutes.includes("/levels"));
 });
 
 test("redirect/deprecation policy uses only 308 and 410", () => {

--- a/tests/site-feeds.test.mjs
+++ b/tests/site-feeds.test.mjs
@@ -73,7 +73,6 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
       terms: { metadata: { updatedAt: "2026-03-29" } },
       about: { metadata: { updatedAt: "2026-03-30" } },
       playing: { metadata: { updatedAt: "2026-07-05" } },
-      levels: { metadata: { updatedAt: "2026-07-05" } },
     },
     playerRoutes: ["/players/refereefox", "/blog/research-map"],
     generatedAt: "2026-05-24T00:00:00.000Z",
@@ -84,7 +83,7 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
   const sitemap = renderSitemap(routes);
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/</loc><lastmod>2026-03-27</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/playing</loc><lastmod>2026-07-05</lastmod>"));
-  assert.ok(sitemap.includes("<loc>https://kriegspiel.org/levels</loc><lastmod>2026-07-05</lastmod>"));
+  assert.ok(!sitemap.includes("<loc>https://kriegspiel.org/levels</loc>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/rules/berkeley</loc><lastmod>2026-04-01</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/players/refereefox</loc><lastmod>2026-05-24</lastmod>"));
 });

--- a/tests/trust-rules-pages.test.mjs
+++ b/tests/trust-rules-pages.test.mjs
@@ -160,11 +160,11 @@ test('site markdown pages keep wrapped tables as scrollable tables on narrow scr
 
 test('site markdown pages include tier feature matrix styles', () => {
   const html = renderSiteMarkdownPage({
-    metadata: { title: 'Levels and pricing', summary: 'Levels page', slug: 'levels' },
+    metadata: { title: 'Pricing matrix', summary: 'Pricing table page', slug: 'pricing-matrix' },
     bodyHtml: '<div class="table-wrap tier-feature-table-wrap" data-tier-feature-table><div class="tier-feature-table__frozen-header" data-tier-feature-table-header></div><div class="tier-feature-table__body-scroll" data-tier-feature-table-body></div></div>'
   });
 
-  assert.ok(html.includes('<section class="content-section content-section--wide"><article class="prose-card prose-card--wide">'));
+  assert.ok(html.includes('<section class="content-section"><article class="prose-card">'));
   assert.ok(html.includes('.content-section--wide{width:100%;}'));
   assert.ok(html.includes('.tier-feature-table-wrap{overflow:visible;border:1px solid var(--border);'));
   assert.ok(html.includes('isolation:isolate;position:relative;'));


### PR DESCRIPTION
## Summary
- stop generating `/levels` on kriegspiel.org
- remove `/levels` from navigation, route contracts, sitemap generation, smoke, SEO, and structured-data default checks
- add negative build/sitemap assertions so the route stays removed
- bump ks-home to v. 1.3.31

## Rationale
The public levels page is being retired. The subscription experience in the app is now the canonical surface for tier details.

## Related
- Companion content cleanup: Kriegspiel/ks-content#175

## Tests
- `npm ci`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm test`
- `npm run lint`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm run build`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm run routes:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm run test:smoke`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm run seo:validate`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm run structured-data:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-remove-levels-content npm run content:schema:check`
- `test ! -e dist/levels/index.html && ! rg -q 'https://kriegspiel.org/levels' dist/sitemap.xml`\n- `git diff --check`\n\n## Deployment notes\nDeploy/refresh ks-home after both PRs merge, then verify `https://kriegspiel.org/levels` returns the site 404 and the live sitemap no longer includes `/levels`.