### PR TITLE
Update public Gemini subscription catalog

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.3.34
+
+- **Subscription**: show Gemini 3.1 Flash-Lite as the visible T3 Gemini model
+  and remove Gemini 2.5 variants from the public tier matrix.
+
 ## ks-home v. 1.3.33
 
 - **Subscription**: keep only Llama 4 Maverick and Gemma 4 31B visible in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.33",
+      "version": "1.3.34",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -491,7 +491,6 @@ const PUBLIC_SUBSCRIPTION_T2_BOTS = [
   ['T2 OpenAI', [['GPTNano', '/user/llm_gptnano'], ['GPT-OSS', '/user/llm_gptoss120b']]],
   ['T2 Anthropic', [['Claude Haiku', '/user/llm_haiku']]],
   ['T2 DeepSeek', [['V4 Flash', '/user/llm_deepseekv4_flash']]],
-  ['T2 Gemini', [['2.5 Flash-Lite', '/user/llm_gemini25_lite'], ['3.1 Flash-Lite', '/user/llm_gemini31_lite']]],
   ['T2 Llama', [['4 Maverick', '/user/llm_llama4_maverick']]],
   ['T2 Mistral', [['Small 3.2', '/user/llm_mistral_small32']]],
   ['T2 Gemma', [['4 31B', '/user/llm_gemma4_31b']]],
@@ -504,7 +503,7 @@ const PUBLIC_SUBSCRIPTION_T2_BOTS = [
 const PUBLIC_SUBSCRIPTION_T3_BOTS = [
   ['T3 OpenAI', ['GPT-5.5']],
   ['T3 Anthropic', ['Claude Sonnet 5']],
-  ['T3 Gemini', ['2.5 Flash']],
+  ['T3 Gemini', [['3.1 Flash-Lite', '/user/llm_gemini31_lite']]],
   ['T3 Mistral', [['Large 3', '/user/llm_mistral_large3']]],
   ['T3 Nemotron', [['Ultra', '/user/llm_nemotron_ultra']]],
   ['T3 Qwen', [['3.6 Flash', '/user/llm_qwen36_flash'], 'Plus']],

--- a/tests/subscription-page.test.mjs
+++ b/tests/subscription-page.test.mjs
@@ -42,6 +42,14 @@ test('public subscription page invites free signup and omits app billing state',
   assert.ok(!html.includes('/user/llm_gemma3_27b'));
   assert.ok(!html.includes('3 4B'));
   assert.ok(!html.includes('3 27B'));
+  assert.ok(!html.includes('T2 Gemini'));
+  assert.ok(!html.includes('/user/llm_gemini25_lite'));
+  assert.ok(!html.includes('/user/openrouter_gemini25_lite'));
+  assert.ok(!html.includes('2.5 Flash-Lite'));
+  assert.ok(!html.includes('2.5 Flash'));
+  assert.ok(html.includes('T3 Gemini'));
+  assert.ok(html.includes('3.1 Flash-Lite'));
+  assert.ok(html.includes('/user/llm_gemini31_lite'));
   assert.ok(html.includes('T3 Mistral'));
   assert.ok(html.includes('Large 3'));
   assert.ok(html.includes('Lower-tier bots included.'));


### PR DESCRIPTION
## Summary
- remove visible Gemini 2.5 entries from the public subscription matrix
- show Gemini 3.1 Flash-Lite as the visible T3 Gemini model
- bump public site to 1.3.34

## Rationale
The public subscription page should match the app subscription catalog and explain the current visible tier ladder without exposing older Gemini variants.

## Tests
- node --test tests/subscription-page.test.mjs
- npm run build

## Verified commit
da70569

## Deployment notes
Refresh the public site after merge so https://kriegspiel.org/subscription matches the app catalog.