### PR TITLE
Move subscription navigation to footer

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.0
+
+- **Navigation**: move Subscription out of the header and into the Game footer
+  links as the third option.
+
 ## ks-home v. 1.3.34
 
 - **Subscription**: show Gemini 3.1 Flash-Lite as the visible T3 Gemini model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.3.34",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.3.34",
+      "version": "1.4.0",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.3.34",
+  "version": "1.4.0",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -59,7 +59,7 @@ function renderFooterLink([href, label]) {
 
 function renderFooter(footerEntry) {
   const fallbackGroups = [
-    { title: 'Game', links: [[APP_PLAY_URL, 'Play online'], ['/playing', 'Playing guide'], ['/leaderboard', 'Leaderboard']] },
+    { title: 'Game', links: [[APP_PLAY_URL, 'Play online'], ['/playing', 'Playing guide'], ['/subscription', 'Subscription'], ['/leaderboard', 'Leaderboard']] },
     { title: 'Rules', links: [['/rules/berkeley', 'Berkeley'], ['/rules/cincinnati', 'Cincinnati'], ['/rules/wild16', 'Wild 16'], ['/rules/rand', 'RAND'], ['/rules/english', 'English'], ['/rules/crazykrieg', 'CrazyKrieg'], ['/rules/comparison/', 'Comparison']] },
     { title: 'Communication', links: [['/blog', 'Blog'], ['/changelog', 'Changelog'], ['/feed.xml', 'RSS'], ['/about', 'About']] },
     { title: 'Development', links: [['https://api.kriegspiel.org/docs', 'API docs'], ['https://github.com/Kriegspiel', 'GitHub']] },
@@ -254,7 +254,7 @@ function renderStatsGrid(stats = {}) {
 
 export function renderShell({ title, description, main, activeNav = '/', canonicalPath = '/', structuredData = null, ogType = 'website', footerEntry = null }) {
   const playHref = APP_PLAY_URL;
-  const nav = [['/leaderboard', 'Leaderboard'], ['/blog', 'Blog'], ['/rules', 'Rules'], ['/subscription', 'Subscription'], [playHref, 'Play']];
+  const nav = [['/leaderboard', 'Leaderboard'], ['/blog', 'Blog'], ['/rules', 'Rules'], [playHref, 'Play']];
   const navHtml = nav.map(([href, label]) => {
     const playClass = href === playHref ? ' site-header__play button-link button-link--primary' : '';
     return `<a class="site-nav__link${playClass}" href="${href}" ${activeNav === href ? 'aria-current="page"' : ''}>${label}</a>`;

--- a/tests/home-leaderboard-pages.test.mjs
+++ b/tests/home-leaderboard-pages.test.mjs
@@ -130,6 +130,7 @@ test("leaderboard page includes resilient state containers, telemetry hooks, and
   assert.ok(navHtml.includes('>Blog</a>'));
   assert.ok(navHtml.includes('>Rules</a>'));
   assert.ok(navHtml.includes('>Play</a>'));
+  assert.ok(!navHtml.includes('>Subscription</a>'));
   assert.ok(html.includes('>Rules</h2>'));
   assert.ok(html.includes('>Communication</h2>'));
   assert.ok(html.includes('X.com (@kriegspiel_org)'));

--- a/tests/pages-branches.test.mjs
+++ b/tests/pages-branches.test.mjs
@@ -55,6 +55,7 @@ test("renderShell falls back canonical paths and footer variants", () => {
   assert.ok(!emptyFooterHtml.includes("filter:brightness(1.08);z-index:4"));
   assert.ok(!emptyFooterHtml.includes(".fen-board__grid .fen-board__square:focus-visible{outline:2px solid var(--text);outline-offset:-2px;z-index:5;}"));
   assert.ok(emptyFooterHtml.includes('aria-current="page">Play</a>'));
+  assert.ok(!emptyFooterHtml.includes(">Subscription</a>"));
   assert.ok(!emptyFooterHtml.includes(">Rules</h2>"));
 
   const fallbackFooterHtml = renderShell({
@@ -63,7 +64,8 @@ test("renderShell falls back canonical paths and footer variants", () => {
     main: "<p>hello</p>",
   });
   assert.ok(fallbackFooterHtml.includes(">Game</h2>"));
-  assert.ok(fallbackFooterHtml.includes('<a class="footer__link" href="/playing">Playing guide</a>'));
+  const gameFooter = footerGroupHtml(fallbackFooterHtml, "Game");
+  assert.ok(gameFooter.includes('<a class="footer__link footer__link--external" href="https://app.kriegspiel.org/" target="_blank" rel="noreferrer noopener">Play online</a></li><li><a class="footer__link" href="/playing">Playing guide</a></li><li><a class="footer__link" href="/subscription">Subscription</a></li><li><a class="footer__link" href="/leaderboard">Leaderboard</a>'));
   assert.ok(fallbackFooterHtml.includes(">Rules</h2>"));
   assert.ok(!fallbackFooterHtml.includes('<a href="/rules/dutch">Dutch</a>'));
   assert.ok(fallbackFooterHtml.includes(">Communication</h2>"));

--- a/tests/subscription-page.test.mjs
+++ b/tests/subscription-page.test.mjs
@@ -56,7 +56,10 @@ test('public subscription page invites free signup and omits app billing state',
   assert.ok(!html.includes('llm_mistral_nemo'));
   assert.ok(!html.includes('>Nemo</a>'));
   assert.ok(html.includes('Persistent player name'));
-  assert.ok(html.includes('aria-current="page">Subscription</a>'));
+  const navHtml = html.match(/<nav class="site-nav" aria-label="Primary">([\s\S]*?)<\/nav>/)?.[1] || '';
+  assert.ok(!navHtml.includes('>Subscription</a>'));
+  const gameFooterHtml = html.match(/<section class="footer__group" aria-label="Game">([\s\S]*?)<\/section>/)?.[1] || '';
+  assert.ok(gameFooterHtml.includes('<a class="footer__link" href="/subscription">Subscription</a>'));
   assert.ok(!html.includes('Manage billing'));
   assert.ok(!html.includes('Open payment form'));
   assert.ok(!html.includes('Selected'));


### PR DESCRIPTION
Summary
- Remove Subscription from the public site header navigation.
- Add Subscription to the fallback Game footer links as the third item.
- Bump ks-home to 1.4.0 and update renderer tests.

Rationale
- Subscription should remain discoverable from footer game options without competing with the primary header actions.

Tests
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-subscription-footer npm test
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-subscription-footer npm run content:schema:check
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-subscription-footer npm run routes:validate
- KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-subscription-footer npm run build

Deployment notes
- Merge and deploy with the paired ks-content footer PR so the content-driven footer includes Subscription in production.