### PR TITLE
Hide Nemotron Nano from public subscription matrix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.1
+
+- **Subscription**: hide Nemotron Nano from the visible public tier matrix while
+  preserving direct bot profile access.
+
 ## ks-home v. 1.4.0
 
 - **Navigation**: move Subscription out of the header and into the Game footer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -495,7 +495,7 @@ const PUBLIC_SUBSCRIPTION_T2_BOTS = [
   ['T2 Mistral', [['Small 3.2', '/user/llm_mistral_small32']]],
   ['T2 Gemma', [['4 31B', '/user/llm_gemma4_31b']]],
   ['T2 GLM', [['4.7 Flash', '/user/llm_glm47_flash'], ['4.5 Air', '/user/llm_glm45_air']]],
-  ['T2 Nemotron', [['Nano', '/user/llm_nemotron_nano'], ['Super', '/user/llm_nemotron_super']]],
+  ['T2 Nemotron', [['Super', '/user/llm_nemotron_super']]],
   ['T2 Kimi', [['K2.5', '/user/llm_kimi_k25']]],
   ['T2 Hermes', [['4 70B', '/user/llm_hermes4_70b']]],
   ['T2 Phi', [['4', '/user/llm_phi4']]],

--- a/tests/subscription-page.test.mjs
+++ b/tests/subscription-page.test.mjs
@@ -47,6 +47,10 @@ test('public subscription page invites free signup and omits app billing state',
   assert.ok(!html.includes('/user/openrouter_gemini25_lite'));
   assert.ok(!html.includes('2.5 Flash-Lite'));
   assert.ok(!html.includes('2.5 Flash'));
+  assert.ok(!html.includes('/user/llm_nemotron_nano'));
+  assert.ok(!html.includes('>Nano</a>'));
+  assert.ok(html.includes('/user/llm_nemotron_super'));
+  assert.ok(html.includes('>Super</a>'));
   assert.ok(html.includes('T3 Gemini'));
   assert.ok(html.includes('3.1 Flash-Lite'));
   assert.ok(html.includes('/user/llm_gemini31_lite'));


### PR DESCRIPTION
Summary
- Hide Nemotron Nano from the public /subscription tier matrix.
- Keep Nemotron Super visible in T2 and leave direct bot profile links untouched elsewhere.
- Bump ks-home version to 1.4.1.

Rationale
- The public subscription page should match the app page's visible promoted model list while keeping historical/direct-access bots available.

Tests
- node --test tests/subscription-page.test.mjs
- npm run routes:validate
- npm run build
- npm test
- npm run content:schema:check

Notes
- Gemini 2.5 Flash-Lite was already hidden from the public matrix; existing tests keep that coverage.