### PR TITLE
Make public subscription table compact

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.2
+
+- **Subscription**: make the public tier matrix more compact so the levels fit
+  the viewport more comfortably.
+
 ## ks-home v. 1.4.1
 
 - **Subscription**: hide Nemotron Nano from the visible public tier matrix while

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -623,6 +623,10 @@ function subscriptionPublicStyles() {
     `.subscription-tier-card{display:grid;gap:1rem;}`,
     `.subscription-tier-card h2{margin:0;}`,
     `.subscription-tier-table-wrap{margin-top:0;}`,
+    `.subscription-tier-table-wrap .tier-feature-table{min-width:60rem;}`,
+    `.subscription-tier-table-wrap .tier-feature-table__feature-col{width:9.5rem;}`,
+    `.subscription-tier-table-wrap .tier-feature-table__tier-col{width:calc((100% - 9.5rem) / var(--tier-feature-tier-count,7));}`,
+    `.prose-card .subscription-tier-table-wrap .tier-feature-table--header thead th:first-child,.prose-card .subscription-tier-table-wrap .tier-feature-table__body-scroll .tier-feature-table tbody th:first-child,.prose-card .subscription-tier-table-wrap .tier-feature-table__body-scroll .tier-feature-table tbody td:first-child{width:9.5rem;min-width:9.5rem;}`,
     `.subscription-tier-table .tier-feature-table__heading{min-height:7.2rem;}`,
     `.subscription-tier-table .tier-feature-table__feature-col{text-align:left;}`,
     `.subscription-tier-price--stacked{display:grid;gap:.08rem;}`,
@@ -641,7 +645,7 @@ function subscriptionPublicStyles() {
     `html[data-theme="dark"] .subscription-public-invite h2,html[data-theme="dark"] .subscription-public-invite p,html[data-theme="dark"] .subscription-public-invite__eyebrow{color:#fff4c2;}`,
     `html[data-theme="dark"] .subscription-public-invite .button-link--primary{background:#f4ede4;border-color:#f4ede4;color:#100d0a;}`,
     `html[data-theme="dark"] .subscription-public-invite .button-link--secondary{background:rgba(28,23,18,.82);border-color:rgba(244,237,228,.28);color:#f4ede4;}`,
-    `@media (max-width:900px){.subscription-public-invite{grid-template-columns:1fr;}.subscription-public-invite__actions{justify-content:flex-start;}.subscription-tier-table .tier-feature-table__heading{min-height:6.6rem;}}`
+    `@media (max-width:900px){.subscription-public-invite{grid-template-columns:1fr;}.subscription-public-invite__actions{justify-content:flex-start;}.subscription-tier-table-wrap .tier-feature-table{min-width:54rem;}.subscription-tier-table-wrap .tier-feature-table__feature-col{width:8.5rem;}.subscription-tier-table-wrap .tier-feature-table__tier-col{width:calc((100% - 8.5rem) / var(--tier-feature-tier-count,7));}.prose-card .subscription-tier-table-wrap .tier-feature-table--header thead th:first-child,.prose-card .subscription-tier-table-wrap .tier-feature-table__body-scroll .tier-feature-table tbody th:first-child,.prose-card .subscription-tier-table-wrap .tier-feature-table__body-scroll .tier-feature-table tbody td:first-child{width:8.5rem;min-width:8.5rem;}.subscription-tier-table .tier-feature-table__heading{min-height:6.6rem;}}`
   ].join('');
 }
 

--- a/tests/subscription-page.test.mjs
+++ b/tests/subscription-page.test.mjs
@@ -8,6 +8,9 @@ test('public subscription page invites free signup and omits app billing state',
 
   assert.ok(html.includes('Kriegspiel — Subscription'));
   assert.ok(html.includes('<h1>Subscription</h1>'));
+  assert.ok(html.includes('.subscription-tier-table-wrap .tier-feature-table{min-width:60rem;}'));
+  assert.ok(html.includes('.subscription-tier-table-wrap .tier-feature-table__feature-col{width:9.5rem;}'));
+  assert.ok(html.includes('@media (max-width:900px){.subscription-public-invite{grid-template-columns:1fr;}.subscription-public-invite__actions{justify-content:flex-start;}.subscription-tier-table-wrap .tier-feature-table{min-width:54rem;}'));
   assert.ok(html.includes('Create a profile and start playing.'));
   assert.ok(html.includes('The free Casual level already includes human games, completed-game review, rating history, and simple bots.'));
   assert.ok(html.includes('href="https://app.kriegspiel.org/auth/register"'));


### PR DESCRIPTION
Summary
- Add subscription-page-specific compact sizing for the public tier matrix.
- Reduce the public subscription table min-width from the shared 86rem default to 60rem, with a 54rem compact breakpoint below 900px.
- Narrow the sticky Feature column for this public subscription matrix.
- Bump ks-home to 1.4.2.

Rationale
- The public /subscription tier matrix should fit common desktop/tablet widths more comfortably without changing the shared tier-table styling used by other content pages.

Tests
- node --test tests/subscription-page.test.mjs
- npm run routes:validate
- npm run build
- npm run content:schema:check
- generated subscription compact CSS check
- npm test

Notes
- Playwright is not installed in this ks-home worktree, so validation used generated HTML/CSS and the existing test/build suite.