### PR TITLE
Redirect subscription page to app

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.3
+
+- **Subscription**: redirect the public `/subscription` URL to the canonical
+  app subscription page and remove the duplicate page from the sitemap.
+
 ## ks-home v. 1.4.2
 
 - **Subscription**: make the public tier matrix more compact so the levels fit

--- a/contracts/routes.json
+++ b/contracts/routes.json
@@ -35,6 +35,12 @@
       "reason": "Canonical Wild16 rules route dropped the hyphen to match product naming"
     },
     {
+      "from": "/subscription",
+      "to": "https://app.kriegspiel.org/subscription",
+      "status": 308,
+      "reason": "Subscription tiers are canonical in the app so logged-in and public visitors use one page"
+    },
+    {
       "from": "/rules/old",
       "to": null,
       "status": 410,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { getContentRoot, loadCollection, loadSingletonEntry } from '../src/content-utils.mjs';
-import { renderHomePage, renderLeaderboardPage, renderPublicProfilePage, renderSimplePage, renderBlogIndex, renderBlogDetail, renderBlogArchive, renderChangelogIndex, renderChangelogDetail, renderRulesPage, renderRuleDetailPage, renderRulesComparisonPage, renderSubscriptionPage, renderRedirectPage, renderSiteMarkdownPage } from '../src/pages.mjs';
+import { renderHomePage, renderLeaderboardPage, renderPublicProfilePage, renderSimplePage, renderBlogIndex, renderBlogDetail, renderBlogArchive, renderChangelogIndex, renderChangelogDetail, renderRulesPage, renderRuleDetailPage, renderRulesComparisonPage, renderRedirectPage, renderSiteMarkdownPage } from '../src/pages.mjs';
 import { buildSitemapRoutes, buildUpdateFeedEntries, renderAtomFeed, renderRssFeed, renderSitemap } from '../src/site-feeds.mjs';
 
 const dist = path.resolve(process.cwd(), 'dist');
@@ -95,7 +95,7 @@ writePage(path.join(dist, 'blog/archive/index.html'), renderBlogArchive(blogEntr
 writePage(path.join(dist, 'changelog/index.html'), renderChangelogIndex(changelogEntries, footerEntry));
 writePage(path.join(dist, 'rules/index.html'), renderRulesPage(rulesEntries, changelogEntries, footerEntry));
 writePage(path.join(dist, 'rules/comparison/index.html'), renderRulesComparisonPage(rulesEntries, footerEntry));
-writePage(path.join(dist, 'subscription/index.html'), renderSubscriptionPage(footerEntry));
+writePage(path.join(dist, 'subscription/index.html'), renderRedirectPage({ fromPath: '/subscription', toPath: 'https://app.kriegspiel.org/subscription', title: 'Subscription moved', footerEntry }));
 writePage(path.join(dist, 'privacy/index.html'), renderSiteMarkdownPage(privacyEntry, footerEntry));
 writePage(path.join(dist, 'terms/index.html'), renderSiteMarkdownPage(termsEntry, footerEntry));
 writePage(path.join(dist, 'about/index.html'), renderSiteMarkdownPage(aboutEntry, footerEntry));

--- a/scripts/seo-validate.mjs
+++ b/scripts/seo-validate.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const arg = process.argv.find((a) => a.startsWith("--routes="));
-const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/subscription,/playing").split(",");
+const routes = (arg ? arg.split("=")[1] : "/,/leaderboard,/blog,/changelog,/rules,/playing").split(",");
 
 const requiredChecks = [
   { name: "<title>", re: /<title>[^<]+<\/title>/i },

--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -19,6 +19,11 @@ const MIME_TYPES = new Map([
   [".ico", "image/x-icon"]
 ]);
 
+const REDIRECTS = new Map([
+  ["/subscription", "https://app.kriegspiel.org/subscription"],
+  ["/subscription/", "https://app.kriegspiel.org/subscription"]
+]);
+
 const args = new Map();
 for (let i = 2; i < process.argv.length; i += 1) {
   const arg = process.argv[i];
@@ -54,6 +59,17 @@ const server = http.createServer((req, res) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
     let pathname = decodeURIComponent(url.pathname);
     if (pathname.includes("\0")) throw new Error("invalid path");
+
+    const redirectLocation = REDIRECTS.get(pathname);
+    if (redirectLocation) {
+      res.writeHead(308, {
+        Location: redirectLocation,
+        "Cache-Control": "public, max-age=300",
+        "Content-Type": "text/plain; charset=utf-8"
+      });
+      res.end(method === "HEAD" ? undefined : `Permanent Redirect: ${redirectLocation}\n`);
+      return;
+    }
 
     let filePath = resolvePath(pathname);
     if (!filePath) {

--- a/scripts/sitemap-generate.mjs
+++ b/scripts/sitemap-generate.mjs
@@ -29,7 +29,7 @@ if (process.argv.includes("--check")) {
   assert.ok(xml.includes("https://kriegspiel.org/blog"));
   assert.ok(xml.includes("https://kriegspiel.org/changelog"));
   assert.ok(xml.includes("https://kriegspiel.org/rules/berkeley"));
-  assert.ok(xml.includes("https://kriegspiel.org/subscription"));
+  assert.ok(!xml.includes("https://kriegspiel.org/subscription"));
   assert.ok(xml.includes("<lastmod>"));
 }
 console.log("sitemap generated");

--- a/scripts/structured-data-check.mjs
+++ b/scripts/structured-data-check.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const targets = ["/", "/blog", "/changelog", "/rules", "/subscription", "/playing"];
+const targets = ["/", "/blog", "/changelog", "/rules", "/playing"];
 let failures = 0;
 for (const route of targets) {
   const rel = route === "/" ? "index.html" : `${route.replace(/^\//, "")}/index.html`;

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -15,7 +15,11 @@ const APP_ORIGIN = 'https://app.kriegspiel.org';
 const APP_PLAY_URL = `${APP_ORIGIN}/`;
 
 function esc(v = '') { return String(v).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }
-function absUrl(path = '/') { return `${SITE_URL}${path}`; }
+function absUrl(path = '/') {
+  const value = String(path || '/');
+  if (/^https?:\/\//.test(value)) return value;
+  return `${SITE_URL}${value.startsWith('/') ? value : `/${value}`}`;
+}
 function appUrl(path = '/') { return `${APP_ORIGIN}${path.startsWith('/') ? path : `/${path}`}`; }
 const THEME_TOGGLE_SCRIPT = `<script>(function(){var STORAGE_KEY="kriegspiel-theme";var root=document.documentElement;function readStoredTheme(){try{var value=window.localStorage.getItem(STORAGE_KEY);return value==="light"||value==="dark"?value:null;}catch(error){return null;}}function preferredTheme(){var stored=readStoredTheme();if(stored)return stored;return "light";}function applyTheme(theme){root.setAttribute("data-theme",theme);if(document.body){document.body.setAttribute("data-theme",theme);}var metaThemeColor=document.querySelector('meta[name="theme-color"]');if(metaThemeColor){metaThemeColor.setAttribute("content",theme==="dark"?"#100d0a":"#f7efe3");}var button=document.querySelector("[data-theme-toggle]");if(button){var nextTheme=theme==="dark"?"light":"dark";button.setAttribute("aria-pressed",String(theme==="dark"));button.setAttribute("aria-label","Toggle color theme");button.removeAttribute("title");button.setAttribute("data-next-theme",nextTheme);}}function storeTheme(theme){try{window.localStorage.setItem(STORAGE_KEY,theme);}catch(error){}}function toggleTheme(){var current=root.getAttribute("data-theme")||preferredTheme();var next=current==="dark"?"light":"dark";storeTheme(next);applyTheme(next);}root.setAttribute("data-theme",preferredTheme());document.addEventListener("DOMContentLoaded",function(){applyTheme(root.getAttribute("data-theme")||preferredTheme());var button=document.querySelector("[data-theme-toggle]");if(button){button.addEventListener("click",toggleTheme);}});})();</script>`;
 const ATTRIBUTION_SCRIPT = `<script src="/attribution.js?v=${PACKAGE_VERSION}" defer></script>`;

--- a/src/site-feeds.mjs
+++ b/src/site-feeds.mjs
@@ -52,7 +52,6 @@ export function buildSitemapRoutes({
     { path: "/changelog", lastmod: latestEntryDate(changelogEntries) },
     { path: "/rules", lastmod: latestEntryDate(rulesEntries) },
     { path: "/rules/comparison", lastmod: latestEntryDate(rulesEntries) },
-    { path: "/subscription", lastmod: generatedAt },
     { path: "/privacy", lastmod: siteEntries.privacy?.metadata?.updatedAt },
     { path: "/terms", lastmod: siteEntries.terms?.metadata?.updatedAt },
     { path: "/about", lastmod: siteEntries.about?.metadata?.updatedAt },

--- a/tests/build-smoke.test.mjs
+++ b/tests/build-smoke.test.mjs
@@ -23,7 +23,7 @@ test('build emits required public pages', () => {
   assert.ok(feed.includes('<rss version="2.0"'));
   assert.ok(atom.includes('<feed xmlns="http://www.w3.org/2005/Atom"'));
   assert.ok(sitemap.includes('https://kriegspiel.org/rules/berkeley'));
-  assert.ok(sitemap.includes('https://kriegspiel.org/subscription'));
+  assert.ok(!sitemap.includes('https://kriegspiel.org/subscription'));
   assert.ok(sitemap.includes('https://kriegspiel.org/playing'));
   assert.ok(!sitemap.includes('https://kriegspiel.org/levels'));
   assert.ok(sitemap.includes('<lastmod>'));

--- a/tests/site-feeds.test.mjs
+++ b/tests/site-feeds.test.mjs
@@ -83,7 +83,7 @@ test("sitemap includes static, content, and player routes with lastmod", () => {
   const sitemap = renderSitemap(routes);
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/</loc><lastmod>2026-03-27</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/playing</loc><lastmod>2026-07-05</lastmod>"));
-  assert.ok(sitemap.includes("<loc>https://kriegspiel.org/subscription</loc><lastmod>2026-05-24</lastmod>"));
+  assert.ok(!sitemap.includes("<loc>https://kriegspiel.org/subscription</loc>"));
   assert.ok(!sitemap.includes("<loc>https://kriegspiel.org/levels</loc>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/rules/berkeley</loc><lastmod>2026-04-01</lastmod>"));
   assert.ok(sitemap.includes("<loc>https://kriegspiel.org/players/refereefox</loc><lastmod>2026-05-24</lastmod>"));

--- a/tests/static-server-redirect.test.mjs
+++ b/tests/static-server-redirect.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+
+test('static server redirects the public subscription route to the app page', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ks-home-static-'));
+  fs.writeFileSync(path.join(root, 'index.html'), 'ok\n', 'utf8');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const port = await availablePort();
+  const child = spawn(process.execPath, [
+    'scripts/serve-static.mjs',
+    '--root',
+    root,
+    '--host',
+    '127.0.0.1',
+    '--port',
+    String(port),
+  ], {
+    cwd: process.cwd(),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  t.after(() => {
+    child.kill();
+  });
+
+  await waitForServer(`http://127.0.0.1:${port}/`);
+
+  for (const route of ['/subscription', '/subscription/']) {
+    const response = await fetch(`http://127.0.0.1:${port}${route}`, { redirect: 'manual' });
+    assert.equal(response.status, 308);
+    assert.equal(response.headers.get('location'), 'https://app.kriegspiel.org/subscription');
+  }
+});
+
+function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForServer(url) {
+  let lastError = null;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}

--- a/tests/subscription-page.test.mjs
+++ b/tests/subscription-page.test.mjs
@@ -1,76 +1,29 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { renderSubscriptionPage } from '../src/pages.mjs';
+import { renderRedirectPage } from '../src/pages.mjs';
 
-test('public subscription page invites free signup and omits app billing state', () => {
-  const html = renderSubscriptionPage();
+test('public subscription route redirects to the canonical app subscription page', () => {
+  const html = renderRedirectPage({
+    fromPath: '/subscription',
+    toPath: 'https://app.kriegspiel.org/subscription',
+    title: 'Subscription moved',
+  });
 
-  assert.ok(html.includes('Kriegspiel — Subscription'));
-  assert.ok(html.includes('<h1>Subscription</h1>'));
-  assert.ok(html.includes('.subscription-tier-table-wrap .tier-feature-table{min-width:60rem;}'));
-  assert.ok(html.includes('.subscription-tier-table-wrap .tier-feature-table__feature-col{width:9.5rem;}'));
-  assert.ok(html.includes('@media (max-width:900px){.subscription-public-invite{grid-template-columns:1fr;}.subscription-public-invite__actions{justify-content:flex-start;}.subscription-tier-table-wrap .tier-feature-table{min-width:54rem;}'));
-  assert.ok(html.includes('Create a profile and start playing.'));
-  assert.ok(html.includes('The free Casual level already includes human games, completed-game review, rating history, and simple bots.'));
-  assert.ok(html.includes('href="https://app.kriegspiel.org/auth/register"'));
-  assert.ok(html.includes('Create free profile'));
-  assert.ok(html.includes('Why subscriptions help'));
-  assert.ok(html.includes('Paid tiers exist because stronger bots use paid AI tokens, and they bring more challenge, variety, and joy to the game.'));
-  assert.ok(html.includes('>T0</span>'));
-  assert.ok(html.includes('>Guest</span>'));
-  assert.ok(html.includes('>T1</span>'));
-  assert.ok(html.includes('>Casual</span>'));
-  assert.ok(html.includes('>T2</span>'));
-  assert.ok(html.includes('>Club</span>'));
-  assert.ok(html.includes('$10/mo'));
-  assert.ok(html.includes('$100/yr'));
-  assert.ok(html.includes('>T4</span>'));
-  assert.ok(html.includes('>Expert</span>'));
-  assert.ok(html.includes('Random Any'));
-  assert.ok(html.includes('GPTNano'));
-  assert.ok(html.includes('Claude Haiku'));
-  assert.ok(html.includes('T2 Llama'));
-  assert.ok(html.includes('4 Maverick'));
-  assert.ok(html.includes('/user/llm_llama4_maverick'));
-  assert.ok(!html.includes('/user/llm_llama31_8b'));
-  assert.ok(!html.includes('/user/llm_llama4_scout'));
-  assert.ok(!html.includes('openrouter_llama31_8b'));
-  assert.ok(!html.includes('3.1 8B'));
-  assert.ok(!html.includes('4 Scout'));
-  assert.ok(html.includes('T2 Gemma'));
-  assert.ok(html.includes('4 31B'));
-  assert.ok(html.includes('/user/llm_gemma4_31b'));
-  assert.ok(!html.includes('/user/llm_gemma3_4b'));
-  assert.ok(!html.includes('/user/llm_gemma3_27b'));
-  assert.ok(!html.includes('3 4B'));
-  assert.ok(!html.includes('3 27B'));
-  assert.ok(!html.includes('T2 Gemini'));
-  assert.ok(!html.includes('/user/llm_gemini25_lite'));
-  assert.ok(!html.includes('/user/openrouter_gemini25_lite'));
-  assert.ok(!html.includes('2.5 Flash-Lite'));
-  assert.ok(!html.includes('2.5 Flash'));
-  assert.ok(!html.includes('/user/llm_nemotron_nano'));
-  assert.ok(!html.includes('>Nano</a>'));
-  assert.ok(html.includes('/user/llm_nemotron_super'));
-  assert.ok(html.includes('>Super</a>'));
-  assert.ok(html.includes('T3 Gemini'));
-  assert.ok(html.includes('3.1 Flash-Lite'));
-  assert.ok(html.includes('/user/llm_gemini31_lite'));
-  assert.ok(html.includes('T3 Mistral'));
-  assert.ok(html.includes('Large 3'));
-  assert.ok(html.includes('Lower-tier bots included.'));
-  assert.ok(!html.includes('llm_mistral_nemo'));
-  assert.ok(!html.includes('>Nemo</a>'));
-  assert.ok(html.includes('Persistent player name'));
-  const navHtml = html.match(/<nav class="site-nav" aria-label="Primary">([\s\S]*?)<\/nav>/)?.[1] || '';
-  assert.ok(!navHtml.includes('>Subscription</a>'));
-  const gameFooterHtml = html.match(/<section class="footer__group" aria-label="Game">([\s\S]*?)<\/section>/)?.[1] || '';
-  assert.ok(gameFooterHtml.includes('<a class="footer__link" href="/subscription">Subscription</a>'));
+  assert.ok(html.includes('Kriegspiel — Subscription moved'));
+  assert.ok(html.includes('<meta http-equiv="refresh" content="0; url=https://app.kriegspiel.org/subscription" />'));
+  assert.ok(html.includes('<link rel="canonical" href="https://app.kriegspiel.org/subscription" />'));
+  assert.ok(html.includes('This page moved to <a class="text-link" href="https://app.kriegspiel.org/subscription">https://app.kriegspiel.org/subscription</a>.'));
+  assert.ok(!html.includes('Kriegspiel levels'));
+  assert.ok(!html.includes('Create free profile'));
   assert.ok(!html.includes('Manage billing'));
   assert.ok(!html.includes('Open payment form'));
   assert.ok(!html.includes('Selected'));
   assert.ok(!html.includes('Current level'));
   assert.ok(!html.includes('Current tier'));
   assert.ok(!html.includes('Bot availability'));
+  const navHtml = html.match(/<nav class="site-nav" aria-label="Primary">([\s\S]*?)<\/nav>/)?.[1] || '';
+  assert.ok(!navHtml.includes('>Subscription</a>'));
+  const gameFooterHtml = html.match(/<section class="footer__group" aria-label="Game">([\s\S]*?)<\/section>/)?.[1] || '';
+  assert.ok(gameFooterHtml.includes('<a class="footer__link" href="/subscription">Subscription</a>'));
 });


### PR DESCRIPTION
## Summary
- Replace the public `/subscription` page with a redirect to `https://app.kriegspiel.org/subscription`.
- Add runtime 308 redirect handling in the static server for `/subscription` and `/subscription/`.
- Remove `/subscription` from sitemap/SEO validation route lists while keeping the footer link pointed at the canonical app page.
- Bump `ks-home` to `1.4.3` and add release notes.

## Rationale
The app subscription page is now public, so the static site should not maintain a second subscription matrix. Redirecting keeps old links useful while preserving one source of truth.

## Tests
- `npm test`
- `npm run build`
- `npm run lint`
- `npm run routes:validate`
- `npm run sitemap:generate -- --check`
- `npm run seo:validate`
- `npm run structured-data:check`

## Deployment notes
Deploy `ks-home` so `kriegspiel.org/subscription` returns a 308 redirect to `https://app.kriegspiel.org/subscription` and the static sitemap omits the duplicate subscription page.
