### PR TITLE
Refresh site release for 1.4.0 changelog

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.4
+
+- **Changelog and Feeds**: render the public version `1.4.0` release note and
+  refresh the generated changelog, RSS, Atom, and sitemap outputs.
+
 ## ks-home v. 1.4.3
 
 - **Subscription**: redirect the public `/subscription` URL to the canonical

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `ks-home` from `1.4.3` to `1.4.4`.
- Add release notes for rendering the public 1.4.0 changelog and refreshing generated changelog/feed/sitemap output.

## Rationale

The static site is the public surface that renders content changelog entries and update feeds. This refresh pairs with the new `ks-content` 1.4.0 changelog note.

## Tests

- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-release-1.4.0 npm run content:schema:check` at commit `5eaff48`.
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-release-1.4.0 npm test` at commit `5eaff48`.
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-release-1.4.0 npm run feeds:generate -- --check` at commit `5eaff48`.
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-release-1.4.0 npm run build` at commit `5eaff48`.

Verified generated ignored `dist/feed.xml`, `dist/atom.xml`, `dist/changelog/index.html`, `dist/changelog/2026-07-12-v1-4-0/index.html`, and `dist/sitemap.xml` include the 1.4.0 entry when built from the content worktree.

## Deployment notes

- Merge/deploy after the matching `ks-content` changelog PR so the deployed content checkout contains `2026-07-12-v1-4-0`.
- Rebuild the static site with the production content checkout, restart only the static site service, then verify `/changelog/2026-07-12-v1-4-0`, `/feed.xml`, `/atom.xml`, and `/sitemap.xml` on the public site.
