### PR TITLE
Update static LLM subscription catalog

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,13 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.5
+
+- **Subscription Catalog**: keep the static-site subscription renderer aligned
+  with the app catalog for GPT-5.6 Sol/Terra/Luna, Grok 4.5,
+  Gemini 3.5 Flash, Qwen 3.7 Plus, DeepSeek V3.2, MiniMax M3, and
+  Mistral Medium 3.5.
+
 ## ks-home v. 1.4.4
 
 - **Changelog and Feeds**: render the public version `1.4.0` release note and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -494,28 +494,32 @@ const PUBLIC_SUBSCRIPTION_T1_BOTS = [
 const PUBLIC_SUBSCRIPTION_T2_BOTS = [
   ['T2 OpenAI', [['GPTNano', '/user/llm_gptnano'], ['GPT-OSS', '/user/llm_gptoss120b']]],
   ['T2 Anthropic', [['Claude Haiku', '/user/llm_haiku']]],
-  ['T2 DeepSeek', [['V4 Flash', '/user/llm_deepseekv4_flash']]],
+  ['T2 DeepSeek', [['V4 Flash', '/user/llm_deepseekv4_flash'], ['V3.2', '/user/llm_deepseek_v32']]],
   ['T2 Llama', [['4 Maverick', '/user/llm_llama4_maverick']]],
   ['T2 Mistral', [['Small 3.2', '/user/llm_mistral_small32']]],
   ['T2 Gemma', [['4 31B', '/user/llm_gemma4_31b']]],
   ['T2 GLM', [['4.7 Flash', '/user/llm_glm47_flash'], ['4.5 Air', '/user/llm_glm45_air']]],
   ['T2 Nemotron', [['Super', '/user/llm_nemotron_super']]],
+  ['T2 Qwen', [['Plus', '/user/llm_qwen_plus'], ['3.7 Plus', '/user/llm_qwen37_plus']]],
+  ['T2 MiniMax', [['M3', '/user/llm_minimax_m3']]],
   ['T2 Kimi', [['K2.5', '/user/llm_kimi_k25']]],
   ['T2 Hermes', [['4 70B', '/user/llm_hermes4_70b']]],
   ['T2 Phi', [['4', '/user/llm_phi4']]],
 ];
 const PUBLIC_SUBSCRIPTION_T3_BOTS = [
-  ['T3 OpenAI', ['GPT-5.5']],
+  ['T3 OpenAI', [['GPT-5.5', '/user/llm_gpt55'], ['GPT-5.6 Luna', '/user/llm_gpt56_luna']]],
   ['T3 Anthropic', ['Claude Sonnet 5']],
-  ['T3 Gemini', [['3.1 Flash-Lite', '/user/llm_gemini31_lite']]],
-  ['T3 Mistral', [['Large 3', '/user/llm_mistral_large3']]],
+  ['T3 xAI', [['Grok 4.5', '/user/llm_grok45']]],
+  ['T3 Gemini', [['3.1 Flash-Lite', '/user/llm_gemini31_lite'], ['3.5 Flash', '/user/llm_gemini35_flash']]],
+  ['T3 Mistral', [['Large 3', '/user/llm_mistral_large3'], ['Medium 3.5', '/user/llm_mistral_medium35']]],
   ['T3 Nemotron', [['Ultra', '/user/llm_nemotron_ultra']]],
-  ['T3 Qwen', [['3.6 Flash', '/user/llm_qwen36_flash'], 'Plus']],
+  ['T3 Qwen', [['3.6 Flash', '/user/llm_qwen36_flash']]],
   ['T3 Kimi', ['K2 Thinking']],
   ['T3 Hermes', ['3 70B']],
 ];
 const PUBLIC_SUBSCRIPTION_T4_BOTS = [
   ['T4 Anthropic', [['Claude Opus 4.8', '/user/llm_opus48']]],
+  ['T4 OpenAI', [['GPT-5.6 Terra', '/user/llm_gpt56_terra']]],
   ['T4 DeepSeek', [['V4 Pro', '/user/bot_deepseekv4_pro']]],
   ['T4 Gemini', [['3.1 Pro Preview', '/user/llm_gemini31_pro_preview']]],
   ['T4 GLM', [['5.2', '/user/llm_glm52']]],
@@ -523,7 +527,7 @@ const PUBLIC_SUBSCRIPTION_T4_BOTS = [
   ['T4 Hermes', [['4 405B', '/user/llm_hermes4_405b']]],
 ];
 const PUBLIC_SUBSCRIPTION_T5_BOTS = [
-  ['T5 OpenAI', ['GPT-5.5 Pro']],
+  ['T5 OpenAI', [['GPT-5.6 Sol', '/user/llm_gpt56_sol'], 'GPT-5.5 Pro']],
   ['T5 Qwen', ['3.7 Max']],
 ];
 function publicSubscriptionWithLowerTierBots(groups) { return [PUBLIC_SUBSCRIPTION_LOWER_TIER_NOTE, ...groups]; }


### PR DESCRIPTION
## Summary
- Keep the static-site subscription renderer aligned with the new app model catalog.
- Add GPT-5.6 Sol/Terra/Luna, Grok 4.5, Gemini 3.5 Flash, Qwen 3.7 Plus, DeepSeek V3.2, MiniMax M3, and Mistral Medium 3.5.
- Bump site version to `1.4.5` with release notes.

## Rationale
The public `/subscription` route currently redirects to the app, but the static renderer should stay in sync as operator memory and fallback source.

## Tests
- `npm test` (`64 passed`)
- `npm run build`

Verified commit: `df2514e6e71ad3490e4435974a758c33fb131129`

## Deployment Notes
Deploy with the normal `ks-home` refresh when the catalog rollout ships. Verify the `/subscription` redirect still points to `https://app.kriegspiel.org/subscription`.
