### PR TITLE
Move GPT-5.5 and Grok to T5

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.6
+
+- **Subscription Catalog**: move OpenAI GPT-5.5 and xAI Grok 4.5 from T3
+  Strong to T5 Master in the static subscription renderer.
+
 ## ks-home v. 1.4.5
 
 - **Subscription Catalog**: keep the static-site subscription renderer aligned

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -507,9 +507,8 @@ const PUBLIC_SUBSCRIPTION_T2_BOTS = [
   ['T2 Phi', [['4', '/user/llm_phi4']]],
 ];
 const PUBLIC_SUBSCRIPTION_T3_BOTS = [
-  ['T3 OpenAI', [['GPT-5.5', '/user/llm_gpt55'], ['GPT-5.6 Luna', '/user/llm_gpt56_luna']]],
+  ['T3 OpenAI', [['GPT-5.6 Luna', '/user/llm_gpt56_luna']]],
   ['T3 Anthropic', ['Claude Sonnet 5']],
-  ['T3 xAI', [['Grok 4.5', '/user/llm_grok45']]],
   ['T3 Gemini', [['3.1 Flash-Lite', '/user/llm_gemini31_lite'], ['3.5 Flash', '/user/llm_gemini35_flash']]],
   ['T3 Mistral', [['Large 3', '/user/llm_mistral_large3'], ['Medium 3.5', '/user/llm_mistral_medium35']]],
   ['T3 Nemotron', [['Ultra', '/user/llm_nemotron_ultra']]],
@@ -527,7 +526,8 @@ const PUBLIC_SUBSCRIPTION_T4_BOTS = [
   ['T4 Hermes', [['4 405B', '/user/llm_hermes4_405b']]],
 ];
 const PUBLIC_SUBSCRIPTION_T5_BOTS = [
-  ['T5 OpenAI', [['GPT-5.6 Sol', '/user/llm_gpt56_sol'], 'GPT-5.5 Pro']],
+  ['T5 OpenAI', [['GPT-5.6 Sol', '/user/llm_gpt56_sol'], ['GPT-5.5', '/user/llm_gpt55'], 'GPT-5.5 Pro']],
+  ['T5 xAI', [['Grok 4.5', '/user/llm_grok45']]],
   ['T5 Qwen', ['3.7 Max']],
 ];
 function publicSubscriptionWithLowerTierBots(groups) { return [PUBLIC_SUBSCRIPTION_LOWER_TIER_NOTE, ...groups]; }


### PR DESCRIPTION
## Summary

- Moves GPT-5.5 and Grok 4.5 from T3 Strong to T5 Master in the static subscription renderer.
- Bumps `ks-home` to `1.4.6` and updates release notes.

## Rationale

The static/public catalog data should stay aligned with the app subscription model catalog even though `/subscription` redirects to the app.

## Tests

- `npm test -- tests/content-utils.test.mjs` (`64 passed`)
- `npm run build` (passed)
- `git diff --check`

## Deployment Notes

Static-site user-visible/catalog change. After merge, fast-forward `ks-home`, rerun tests/build, restart/refresh affected home service, and verify public smoke.

Verified commit: `7736cf3`
