### PR TITLE
Show GPT-5.5 Pro reasoning in static subscription

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,11 @@ history. New runtime/site releases should add a section at the top when
 `package.json` changes version. Test-only and docs-only changes do not need
 version entries unless they ship a user-visible change.
 
+## ks-home v. 1.4.7
+
+- **Subscription Catalog**: keep the legacy static subscription renderer
+  aligned with app bot links and OpenAI reasoning labels for GPT-5.5 Pro.
+
 ## ks-home v. 1.4.6
 
 - **Subscription Catalog**: move OpenAI GPT-5.5 and xAI Grok 4.5 from T3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ks-home",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ks-home",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "highlight.js": "^11.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ks-home",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "description": "Kriegspiel website contracts and static generation foundation",
   "type": "module",

--- a/src/pages.mjs
+++ b/src/pages.mjs
@@ -526,7 +526,7 @@ const PUBLIC_SUBSCRIPTION_T4_BOTS = [
   ['T4 Hermes', [['4 405B', '/user/llm_hermes4_405b']]],
 ];
 const PUBLIC_SUBSCRIPTION_T5_BOTS = [
-  ['T5 OpenAI', [['GPT-5.6 Sol', '/user/llm_gpt56_sol'], ['GPT-5.5', '/user/llm_gpt55'], 'GPT-5.5 Pro']],
+  ['T5 OpenAI', [['GPT-5.6 Sol', '/user/llm_gpt56_sol', 'no'], ['GPT-5.5', '/user/llm_gpt55', 'no'], ['GPT-5.5 Pro', '/user/llm_gpt55_pro', 'medium']]],
   ['T5 xAI', [['Grok 4.5', '/user/llm_grok45']]],
   ['T5 Qwen', ['3.7 Max']],
 ];
@@ -556,7 +556,9 @@ function renderSubscriptionPrice(price) {
 function renderSubscriptionBotItem(item, index, items) {
   const label = Array.isArray(item) ? item[0] : item;
   const href = Array.isArray(item) ? item[1] : '';
-  const labelHtml = href ? `<a href="${esc(appUrl(href))}">${esc(label)}</a>` : esc(label);
+  const reasoning = Array.isArray(item) ? item[2] : '';
+  const displayLabel = reasoning ? `${label} (reasoning: ${reasoning})` : label;
+  const labelHtml = href ? `<a href="${esc(appUrl(href))}">${esc(displayLabel)}</a>` : esc(displayLabel);
   return `<li>${labelHtml}${index < items.length - 1 ? ';' : ''}</li>`;
 }
 

--- a/tests/subscription-page.test.mjs
+++ b/tests/subscription-page.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { renderRedirectPage } from '../src/pages.mjs';
+import { renderRedirectPage, renderSubscriptionPage } from '../src/pages.mjs';
 
 test('public subscription route redirects to the canonical app subscription page', () => {
   const html = renderRedirectPage({
@@ -26,4 +26,12 @@ test('public subscription route redirects to the canonical app subscription page
   assert.ok(!navHtml.includes('>Subscription</a>'));
   const gameFooterHtml = html.match(/<section class="footer__group" aria-label="Game">([\s\S]*?)<\/section>/)?.[1] || '';
   assert.ok(gameFooterHtml.includes('<a class="footer__link" href="/subscription">Subscription</a>'));
+});
+
+test('static subscription renderer includes OpenAI reasoning labels', () => {
+  const html = renderSubscriptionPage();
+
+  assert.ok(html.includes('<a href="https://app.kriegspiel.org/user/llm_gpt56_sol">GPT-5.6 Sol (reasoning: no)</a>'));
+  assert.ok(html.includes('<a href="https://app.kriegspiel.org/user/llm_gpt55">GPT-5.5 (reasoning: no)</a>'));
+  assert.ok(html.includes('<a href="https://app.kriegspiel.org/user/llm_gpt55_pro">GPT-5.5 Pro (reasoning: medium)</a>'));
 });


### PR DESCRIPTION
## Summary
- Bumps `ks-home` to 1.4.7.
- Adds inline OpenAI reasoning labels to the legacy static subscription renderer for GPT-5.6 Sol, GPT-5.5, and GPT-5.5 Pro.
- Links GPT-5.5 Pro to the app profile and covers the renderer with a focused subscription test.

## Rationale
The app subscription page already shows `GPT-5.5 Pro (reasoning: medium)`, but the static renderer had drifted and still treated GPT-5.5 Pro as plain text.

## Validation
- `node --test tests/subscription-page.test.mjs`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-gpt55-pro-changelog npm run content:schema:check`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-gpt55-pro-changelog npm run build`
- `npm test`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-gpt55-pro-changelog npm run test:e2e:blog-changelog`
- `KS_CONTENT_PATH=/home/codex/dev/kriegspiel/_worktrees/ks-content-gpt55-pro-changelog npm run test:smoke`
- `git diff --check`

## Deployment Notes
Deploy `ks-home` after the paired `ks-content` changelog update is merged so the public changelog page rebuilds with the GPT-5.5 Pro reasoning sentence.
